### PR TITLE
Added sort to unique() so we have consistent output

### DIFF
--- a/geo_utils.py
+++ b/geo_utils.py
@@ -578,7 +578,7 @@ def unique(s):
     except TypeError:
         pass
     else:
-        return list(u.keys())
+        return sorted(list(u.keys()))
 
     # We can't hash all the elements.  Second fastest is to sort,
     # which brings the equal elements together; then duplicates are


### PR DESCRIPTION
The unique() function in geo_utils first tries to use a dictionary to obtain a unique subset of the inputs. However, the keys are directly extracted and returned, meaning on different systems (esp py2 vs py3) you may get different lists, depending on how that particular python version chooses to handle dictionary ordering, and it may not be deterministic. Adding sort keeps a consistent output so that we get the same behaviour, such as when running regression tests.