### PR TITLE
Fixed demoDesignVars to work with localSection DVs

### DIFF
--- a/DVGeometry.py
+++ b/DVGeometry.py
@@ -2129,11 +2129,16 @@ class DVGeometry(object):
         # Loop through design variables
         count = 0
         for key in dvDict:
-            if key in self.DV_listLocal or key in self.DV_listSectionLocal:
+            if key in self.DV_listLocal:
                 if not includeLocal:
                     continue
                 lower = self.DV_listLocal[key].lower
                 upper = self.DV_listLocal[key].upper
+            elif key in self.DV_listSectionLocal:
+                if not includeLocal:
+                    continue
+                lower = self.DV_listSectionLocal[key].lower
+                upper = self.DV_listSectionLocal[key].upper
             elif key in self.DV_listGlobal:
                 lower = self.DV_listGlobal[key].lower
                 upper = self.DV_listGlobal[key].upper


### PR DESCRIPTION
@anilyil, @nbons not sure which one of you is best placed to check this

Previously, when looping through design variables, the demoDesignVars method would check whether the variable appeared in `self.DV_listLocal` or `self.DV_listSectionLocal` and then either way try to get the variable bounds from `self.DV_listLocal` meaning you'd get a `KeyError` if you used `SectionLocal` variables. 