### PR TITLE
Fixing remaining complex cast warning

### DIFF
--- a/pygeo/DVGeometry.py
+++ b/pygeo/DVGeometry.py
@@ -1188,7 +1188,10 @@ class DVGeometry(object):
                 new_vec = -numpy.cross(deriv, self.links_n[ipt])
                 new_vec = geo_utils.rotVbyW(new_vec, deriv, self.rot_theta[
                         self.curveIDNames[ipt]](self.links_s[ipt])*numpy.pi/180)
-                new_pts[ipt] = base_pt + new_vec*scale
+                if isComplex:
+                    new_pts[ipt] = base_pt + new_vec*scale
+                else:
+                    new_pts[ipt] = numpy.real(base_pt + new_vec*scale)
 
             else:
                 rotX = geo_utils.rotxM(self.rot_x[

--- a/tests/reg_tests/commonUtils.py
+++ b/tests/reg_tests/commonUtils.py
@@ -16,7 +16,7 @@ def printHeader(testName):
 # DVGeometry Tests
 ##################
 
-def setupDVGeo(base_path):
+def setupDVGeo(base_path, rotType=None):
     #create the Parent FFD
     FFDFile =  os.path.join(base_path,'../inputFiles/outerBoxFFD.xyz')
     DVGeo = DVGeometry(FFDFile)
@@ -24,7 +24,11 @@ def setupDVGeo(base_path):
     # create a reference axis for the parent
     axisPoints = [[ -1.0,   0.  ,   0.],[ 1.5,   0.,   0.]]
     c1 = Curve(X=axisPoints,k=2)
-    DVGeo.addRefAxis('mainAxis',curve=c1, axis='y')
+    if rotType is not None:
+        DVGeo.addRefAxis('mainAxis',curve=c1, axis='y', rotType=rotType)
+
+    else:
+        DVGeo.addRefAxis('mainAxis',curve=c1, axis='y')
 
     # create the child FFD
     FFDFile = os.path.join(base_path,'../inputFiles/simpleInnerFFD.xyz')

--- a/tests/reg_tests/test_DVGeometry.py
+++ b/tests/reg_tests/test_DVGeometry.py
@@ -3,8 +3,9 @@ import os
 import unittest
 import numpy
 from baseclasses import BaseRegTest
-import commonUtils 
+import commonUtils
 from pygeo import geo_utils, DVGeometry
+from parameterized import parameterized
 
 
 class RegTestPyGeo(unittest.TestCase):
@@ -12,7 +13,7 @@ class RegTestPyGeo(unittest.TestCase):
     N_PROCS = 1
 
     def setUp(self):
-        # Store the path where this current script lives 
+        # Store the path where this current script lives
         # This all paths in the script are relative to this path
         # This is needed to support testflo running directories and files as inputs
         self.base_path = os.path.dirname(os.path.abspath(__file__))
@@ -260,6 +261,54 @@ class RegTestPyGeo(unittest.TestCase):
 
             commonUtils.testSensitivities(DVGeo, refDeriv, handler)
 
+    def test_10_rot0(self, train=False, refDeriv=False):
+        """
+        Test 10: Basic + Nested FFD, local DVs only on parent, global and local on child
+        """
+        refFile = os.path.join(self.base_path,'ref/test_DVGeometry_10.ref')
+        with BaseRegTest(refFile, train=train) as handler:
+            handler.root_print("Test 10: Basic + Nested FFD, local DVs only on parent, global and local on child")
+            DVGeo,DVGeoChild = commonUtils.setupDVGeo(self.base_path, rotType=0)
+
+            #create local DVs on the parent
+            DVGeo.addGeoDVLocal('xdir', lower=-1.0, upper=1.0, axis='x', scale=1.0)
+            DVGeo.addGeoDVLocal('ydir', lower=-1.0, upper=1.0, axis='y', scale=1.0)
+            DVGeo.addGeoDVLocal('zdir', lower=-1.0, upper=1.0, axis='z', scale=1.0)
+
+            DVGeoChild.addGeoDVGlobal('nestedX', -0.5, commonUtils.childAxisPoints,
+                                    lower=-1., upper=0., scale=1.0)
+            DVGeoChild.addGeoDVLocal('childxdir', lower=-1.1, upper=1.1, axis='x', scale=1.0)
+            DVGeoChild.addGeoDVLocal('childydir', lower=-1.1, upper=1.1, axis='y', scale=1.0)
+            DVGeoChild.addGeoDVLocal('childzdir', lower=-1.1, upper=1.1, axis='z', scale=1.0)
+
+            DVGeo.addChild(DVGeoChild)
+
+            commonUtils.testSensitivities(DVGeo, refDeriv, handler)
+
+    def test_10_rot7(self, train=False, refDeriv=False):
+        """
+        Test 10: Basic + Nested FFD, local DVs only on parent, global and local on child
+        """
+        refFile = os.path.join(self.base_path,'ref/test_DVGeometry_10.ref')
+        with BaseRegTest(refFile, train=train) as handler:
+            handler.root_print("Test 10: Basic + Nested FFD, local DVs only on parent, global and local on child")
+            DVGeo,DVGeoChild = commonUtils.setupDVGeo(self.base_path, rotType=7)
+
+            #create local DVs on the parent
+            DVGeo.addGeoDVLocal('xdir', lower=-1.0, upper=1.0, axis='x', scale=1.0)
+            DVGeo.addGeoDVLocal('ydir', lower=-1.0, upper=1.0, axis='y', scale=1.0)
+            DVGeo.addGeoDVLocal('zdir', lower=-1.0, upper=1.0, axis='z', scale=1.0)
+
+            DVGeoChild.addGeoDVGlobal('nestedX', -0.5, commonUtils.childAxisPoints,
+                                    lower=-1., upper=0., scale=1.0)
+            DVGeoChild.addGeoDVLocal('childxdir', lower=-1.1, upper=1.1, axis='x', scale=1.0)
+            DVGeoChild.addGeoDVLocal('childydir', lower=-1.1, upper=1.1, axis='y', scale=1.0)
+            DVGeoChild.addGeoDVLocal('childzdir', lower=-1.1, upper=1.1, axis='z', scale=1.0)
+
+            DVGeo.addChild(DVGeoChild)
+
+            commonUtils.testSensitivities(DVGeo, refDeriv, handler)
+
 
     def train_11(self, train=True, refDeriv=True):
         self.test_11(train=train, refDeriv=refDeriv)
@@ -272,6 +321,58 @@ class RegTestPyGeo(unittest.TestCase):
         with BaseRegTest(refFile, train=train) as handler:
             handler.root_print("Test 11: Basic + Nested FFD, global DVs and local DVs on parent local on child")
             DVGeo,DVGeoChild = commonUtils.setupDVGeo(self.base_path)
+
+            #create global DVs on the parent
+            DVGeo.addGeoDVGlobal('mainX', -1.0, commonUtils.mainAxisPoints,
+                                lower=-1., upper=0., scale=1.0)
+            #create local DVs on the parent
+            DVGeo.addGeoDVLocal('xdir', lower=-1.0, upper=1.0, axis='x', scale=1.0)
+            DVGeo.addGeoDVLocal('ydir', lower=-1.0, upper=1.0, axis='y', scale=1.0)
+            DVGeo.addGeoDVLocal('zdir', lower=-1.0, upper=1.0, axis='z', scale=1.0)
+
+            #create global DVs on the child
+            DVGeoChild.addGeoDVLocal('childxdir', lower=-1.1, upper=1.1, axis='x', scale=1.0)
+            DVGeoChild.addGeoDVLocal('childydir', lower=-1.1, upper=1.1, axis='y', scale=1.0)
+            DVGeoChild.addGeoDVLocal('childzdir', lower=-1.1, upper=1.1, axis='z', scale=1.0)
+
+            DVGeo.addChild(DVGeoChild)
+
+            commonUtils.testSensitivities(DVGeo, refDeriv, handler)
+
+    def test_11_rot0(self, train=False, refDeriv=False):
+        """
+        Test 11: Basic + Nested FFD, global DVs and local DVs on parent local on child
+        """
+        refFile = os.path.join(self.base_path,'ref/test_DVGeometry_11.ref')
+        with BaseRegTest(refFile, train=train) as handler:
+            handler.root_print("Test 11: Basic + Nested FFD, global DVs and local DVs on parent local on child, using rotType=0")
+            DVGeo,DVGeoChild = commonUtils.setupDVGeo(self.base_path,rotType=0)
+
+            #create global DVs on the parent
+            DVGeo.addGeoDVGlobal('mainX', -1.0, commonUtils.mainAxisPoints,
+                                lower=-1., upper=0., scale=1.0)
+            #create local DVs on the parent
+            DVGeo.addGeoDVLocal('xdir', lower=-1.0, upper=1.0, axis='x', scale=1.0)
+            DVGeo.addGeoDVLocal('ydir', lower=-1.0, upper=1.0, axis='y', scale=1.0)
+            DVGeo.addGeoDVLocal('zdir', lower=-1.0, upper=1.0, axis='z', scale=1.0)
+
+            #create global DVs on the child
+            DVGeoChild.addGeoDVLocal('childxdir', lower=-1.1, upper=1.1, axis='x', scale=1.0)
+            DVGeoChild.addGeoDVLocal('childydir', lower=-1.1, upper=1.1, axis='y', scale=1.0)
+            DVGeoChild.addGeoDVLocal('childzdir', lower=-1.1, upper=1.1, axis='z', scale=1.0)
+
+            DVGeo.addChild(DVGeoChild)
+
+            commonUtils.testSensitivities(DVGeo, refDeriv, handler)
+
+    def test_11_rot7(self, train=False, refDeriv=False):
+        """
+        Test 11: Basic + Nested FFD, global DVs and local DVs on parent local on child
+        """
+        refFile = os.path.join(self.base_path,'ref/test_DVGeometry_11.ref')
+        with BaseRegTest(refFile, train=train) as handler:
+            handler.root_print("Test 11: Basic + Nested FFD, global DVs and local DVs on parent local on child, using rotType=7")
+            DVGeo,DVGeoChild = commonUtils.setupDVGeo(self.base_path,rotType=7)
 
             #create global DVs on the parent
             DVGeo.addGeoDVGlobal('mainX', -1.0, commonUtils.mainAxisPoints,


### PR DESCRIPTION
## Purpose
#60 covered all the complex casting issues for the default `rotType`, but there was a missing fix to be done for `rotType=0`.
I fixed it using the same approach from the "default" path, see [these lines](https://github.com/mdolab/pygeo/blob/7e8f13937c3ca79d9ad96a3b4c4bba06c96988c1/pygeo/DVGeometry.py#L1233-L1236).
I added duplicates of test 10 and 11 (the most complex testcases we have) to ensure the fix I made did not break the sensitivity calculations. I am using the same ref files of the current tests, because the sensitivities should not change depending on the rotation order.
I moreover added another set of tests duplicates for `rotType=7`, because this rotation type [has a separate path](https://github.com/mdolab/pygeo/blob/7e8f13937c3ca79d9ad96a3b4c4bba06c96988c1/pygeo/DVGeometry.py#L1214-L1228) from the default and the `rotType=0` cases.

I tried to do the same for rotType=8` but in that case additional work needs to be done with tests on [addGeoDVSectionLocal()](https://github.com/mdolab/pygeo/blob/7e8f13937c3ca79d9ad96a3b4c4bba06c96988c1/pygeo/DVGeometry.py#L693) but I have never used this setup.
We possibly want to open a separate issue for extending test coverage in this sense.

NOTE: I tried a more elegant testing set-up using `Parameterized.expand` but I could not make it work. For now I believe this is fine, but I am introducing some code duplication that I am not really happy about. Any input on this is welcome!

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
Standard

## Checklist

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
