### PR TITLE
Fixed wrong variable name

### DIFF
--- a/pygeo/DVGeometry.py
+++ b/pygeo/DVGeometry.py
@@ -1829,8 +1829,8 @@ class DVGeometry(object):
             i += dv.nVal
 
         i = DVCountSpanLoc
-        for key in self.DV_listSpanLocal:
-            dv = self.DV_listSpanLocal[key]
+        for key in self.DV_listSpanwiseLocal:
+            dv = self.DV_listSpanwiseLocal[key]
             dIdx[i:i+dv.nVal] = dIdxDict[dv.name]
             i += dv.nVal
 


### PR DESCRIPTION
## Purpose
Our build bot threw the following error last night:
```
  File "/home/mdolabuser/miniconda/lib/python3.8/site-packages/pygeo/DVGeometry.py", line 1832, in convertDictToSensitivity
    for key in self.DV_listSpanLocal:
AttributeError: 'DVGeometry' object has no attribute 'DV_listSpanLocal'
```

I'm guessing this was just a simple typo, and should be `self.DV_listSpanwiseLocal`.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Apparently this block of code is not tested anywhere in pygeo?

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
