### PR TITLE
Removed unneccesary mpi4py import

### DIFF
--- a/pygeo/DVConstraints.py
+++ b/pygeo/DVConstraints.py
@@ -4,7 +4,6 @@
 import numpy as np
 from . import geo_utils, pyGeo
 from pyspline import pySpline
-from mpi4py import MPI
 from scipy.sparse import csr_matrix
 from collections import OrderedDict
 
@@ -3898,6 +3897,7 @@ class TriangulatedSurfaceConstraint(GeometricConstraint):
         """
         # first compute the length of the intersection surface between the object and surf mesh
         from geograd import geograd_parallel
+        from mpi4py import MPI
 
         mindist_tmp = 0.0
 
@@ -3945,6 +3945,7 @@ class TriangulatedSurfaceConstraint(GeometricConstraint):
         """
         # first compute the length of the intersection surface between the object and surf mesh
         from geograd import geograd_parallel
+        from mpi4py import MPI
 
         deriv_output = geograd_parallel.compute_derivs(
             self.surf1_p0,
@@ -5711,8 +5712,9 @@ class CurvatureConstraint(GeometricConstraint):
         for iSurf in range(self.nSurfs):
             self.curvatureRef += self.evalCurvArea(iSurf)[0]
 
-        if MPI.COMM_WORLD.rank == 0:
-            print("Reference curvature: ", self.curvatureRef)
+        # from mpi4py import MPI
+        # if MPI.COMM_WORLD.rank == 0:
+        #     print("Reference curvature: ", self.curvatureRef)
 
     def evalFunctions(self, funcs, config):
         """
@@ -5828,8 +5830,9 @@ class CurvatureConstraint(GeometricConstraint):
             # Now compute the KS function for mean curvature, equivelent to KS(H*H*dS)
             sigmaH = np.dot(one, np.exp(self.KSCoeff * H * H * dS))
             KSmean = np.log(sigmaH) / self.KSCoeff
-            if MPI.COMM_WORLD.rank == 0:
-                print("Max curvature: ", max(H * H * dS))
+            # from mpi4py import MPI
+            # if MPI.COMM_WORLD.rank == 0:
+            #     print("Max curvature: ", max(H * H * dS))
             return [KSmean, K, H, C]
         else:
             raise Error(

--- a/pygeo/DVGeometry.py
+++ b/pygeo/DVGeometry.py
@@ -5,7 +5,6 @@ import copy
 from collections import OrderedDict
 import numpy as np
 from scipy import sparse
-from mpi4py import MPI
 from pyspline import pySpline
 from . import pyNetwork, pyBlock, geo_utils
 import os
@@ -1953,6 +1952,7 @@ class DVGeometry(object):
                 dIdx_local[i, :] = self.JT[ptSetName].dot(dIdpt[i, :, :].flatten())
 
         if comm:  # If we have a comm, globaly reduce with sum
+            from mpi4py import MPI
             dIdx = comm.allreduce(dIdx_local, op=MPI.SUM)
         else:
             dIdx = dIdx_local

--- a/pygeo/DVGeometry.py
+++ b/pygeo/DVGeometry.py
@@ -1953,7 +1953,7 @@ class DVGeometry(object):
 
         if comm:  # If we have a comm, globaly reduce with sum
             from mpi4py import MPI
-            
+
             dIdx = comm.allreduce(dIdx_local, op=MPI.SUM)
         else:
             dIdx = dIdx_local

--- a/pygeo/DVGeometry.py
+++ b/pygeo/DVGeometry.py
@@ -1953,6 +1953,7 @@ class DVGeometry(object):
 
         if comm:  # If we have a comm, globaly reduce with sum
             from mpi4py import MPI
+            
             dIdx = comm.allreduce(dIdx_local, op=MPI.SUM)
         else:
             dIdx = dIdx_local

--- a/pygeo/__init__.py
+++ b/pygeo/__init__.py
@@ -7,8 +7,3 @@ from .pyBlock import pyBlock
 from .DVConstraints import DVConstraints
 from .DVGeometry import DVGeometry
 from .DVGeometryAxi import DVGeometryAxi
-
-try:
-    from .DVGeometryVSP import DVGeometryVSP
-except ImportError:
-    pass

--- a/tests/reg_tests/test_DVGeometryVSP.py
+++ b/tests/reg_tests/test_DVGeometryVSP.py
@@ -13,7 +13,7 @@ except ImportError:
     missing_openvsp = True
 
 if not missing_openvsp:
-    from pygeo import DVGeometryVSP
+    from pygeo.DVGeometryVSP import DVGeometryVSP
 
 test_params = [
     # # Tutorial scalar JST


### PR DESCRIPTION
## Purpose
Removed the implicit import of `mpi4py` when importing `geo_utils` etc. Closes #85.
Now the example provided by @akleb returns:
```
>>> from pygeo.geo_utils import *
>>> import subprocess
>>> print(subprocess.run("mpirun hostname", shell=True))
bdeb688de7b2
bdeb688de7b2
bdeb688de7b2
bdeb688de7b2
CompletedProcess(args='mpirun hostname', returncode=0)
```

## Backwards imcompatibility
`DVGeometryVSP` import.
**previous:** `from pygeo import DVGeometryVSP`, which no longer works.
**new:** `from pygeo.DVGeometryVSP import DVGeometryVSP`
This will affect a few files in ADflow and personal runscripts. I'll submit a PR to ADflow.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
