### PR TITLE
Replacing Direct Libspline Calls

### DIFF
--- a/pygeo/geo_utils/projection.py
+++ b/pygeo/geo_utils/projection.py
@@ -1,6 +1,6 @@
 import numpy as np
 import sys
-from pyspline import libspline
+from pyspline.utils import line_plane
 from .remove_duplicates import pointReduce
 
 # --------------------------------------------------------------
@@ -31,7 +31,7 @@ def projectNodePID(pt, upVec, p0, v1, v2, uv0, uv1, uv2, PID):
         fail = 2
         return None, None, fail
 
-    tmpSol, tmpPid, nSol = libspline.line_plane(pt, upVec, p0.T, v1.T, v2.T)
+    tmpSol, tmpPid, nSol = line_plane(pt, upVec, p0.T, v1.T, v2.T)
     tmpSol = tmpSol.T
     tmpPid -= 1
 
@@ -129,7 +129,7 @@ def projectNodePIDPosOnly(pt, upVec, p0, v1, v2, uv0, uv1, uv2, PID):
         fail = 1
         return None, fail
 
-    sol, pid, nSol = libspline.line_plane(pt, upVec, p0.T, v1.T, v2.T)
+    sol, pid, nSol = line_plane(pt, upVec, p0.T, v1.T, v2.T)
     sol = sol.T
     pid -= 1
 
@@ -178,7 +178,7 @@ def projectNode(pt, upVec, p0, v1, v2):
         fail = 2
         return None, None, fail
 
-    sol, pid, nSol = libspline.line_plane(pt, upVec, p0.T, v1.T, v2.T)
+    sol, pid, nSol = line_plane(pt, upVec, p0.T, v1.T, v2.T)
     sol = sol.T
 
     # Check to see if any of the solutions happen be identical.
@@ -242,7 +242,7 @@ def projectNodePosOnly(pt, upVec, p0, v1, v2):
         fail = 1
         return None, fail
 
-    sol, pid, nSol = libspline.line_plane(pt, upVec, p0.T, v1.T, v2.T)
+    sol, pid, nSol = line_plane(pt, upVec, p0.T, v1.T, v2.T)
     sol = sol.T
 
     if nSol == 0:

--- a/pygeo/geo_utils/split_quad.py
+++ b/pygeo/geo_utils/split_quad.py
@@ -1,6 +1,6 @@
 import numpy as np
 from .norm import eDist, euclideanNorm
-from pyspline import libspline
+from pyspline.utils import tfi2d
 
 
 def splitQuad(e0, e1, e2, e3, alpha, beta, NO):
@@ -177,7 +177,7 @@ def tfi_2d(e0, e1, e2, e3):
     # e1: Nodes along edge 3. Size Nv x 3
 
     try:
-        X = libspline.tfi2d(e0.T, e1.T, e2.T, e3.T).T
+        X = tfi2d(e0.T, e1.T, e2.T, e3.T).T
     except Exception:
 
         Nu = len(e0)

--- a/pygeo/parameterization/DVGeometryVSP.py
+++ b/pygeo/parameterization/DVGeometryVSP.py
@@ -8,7 +8,7 @@ from mpi4py import MPI
 from baseclasses.utils import Error
 
 # mdolab packages
-from pyspline import libspline
+from pyspline.utils import searchQuads
 
 # openvsp python interface
 try:
@@ -188,7 +188,7 @@ class DVGeometryVSP(object):
             # faceID has the index of the corresponding quad element.
             # uv has the parametric u and v weights of the projected point.
 
-            faceID, uv = libspline.adtprojections(self.pts0.T, (self.conn + 1).T, points.T)
+            faceID, uv = searchQuads(self.pts0.T, (self.conn + 1).T, points.T)
             uv = uv.T
             faceID -= 1  # Convert back to zero-based indexing.
             # after this point we should have the projected points.


### PR DESCRIPTION
## Purpose
Replaced libspline import and direct function usage with a call to pyspline `utils.py` wrapper. Call to `adtprojections` in `DVGeometryVSP.py` was replaced with `searchQuads`.

- Closes [pyspline 23](https://github.com/mdolab/pyspline/issues/23) and #84.
- Pull requests for pyspline changes are [here](https://github.com/mdolab/pyspline/pull/29) and [here](https://github.com/mdolab/pyspline/pull/30).
- Pull request for pylayout changes is [here](https://github.com/mdolab/pylayout/pull/14).

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [X] Maintenance update
- [ ] Other (please describe)

## Checklist
- [X] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [X] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
