### PR TITLE
writeRefAxes fix for Python 3

### DIFF
--- a/pygeo/parameterization/DVGeo.py
+++ b/pygeo/parameterization/DVGeo.py
@@ -2481,7 +2481,7 @@ class DVGeometry:
            extension will be added.
         """
         # Name here doesnt matter, just take the first one
-        self.update(self.points.keys()[0], childDelta=False)
+        self.update(list(self.points.keys())[0], childDelta=False)
 
         gFileName = fileName + "_parent.dat"
         if not len(self.axis) == 0:

--- a/tests/reg_tests/test_DVGeometry.py
+++ b/tests/reg_tests/test_DVGeometry.py
@@ -980,6 +980,32 @@ class RegTestPyGeo(unittest.TestCase):
         shutil.rmtree(ffdPath)
         shutil.rmtree(pointSetPath)
 
+    def test_writeRefAxes(self):
+        DVGeo, DVGeoChild = commonUtils.setupDVGeo(self.base_path)
+        DVGeo.addChild(DVGeoChild)
+
+        # Add a simple point set
+        ptName = "point"
+        pts = np.array(
+            [
+                [0, 0.5, 0.5],
+            ],
+            dtype="float",
+        )
+        DVGeo.addPointSet(points=pts, ptName=ptName)
+
+        # Write out the axes
+        axesPath = os.path.join(self.base_path, "axis")
+        DVGeo.writeRefAxes(axesPath)
+
+        # Check that files were written
+        self.assertTrue(os.path.isfile(axesPath + "_parent.dat"))
+        self.assertTrue(os.path.isfile(axesPath + "_child000.dat"))
+
+        # Delete axis files
+        os.remove(axesPath + "_parent.dat")
+        os.remove(axesPath + "_child000.dat")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->

`.keys()` in Python 3 does not return a list, so `writeRefAxes` has been broken.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

I added a test that just checks if files have been written.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
