### PR TITLE
fix the argsort that caused inconsistent results due to machine precision errors

### DIFF
--- a/pygeo/geo_utils/remove_duplicates.py
+++ b/pygeo/geo_utils/remove_duplicates.py
@@ -131,9 +131,22 @@ def pointReduce(points, nodeTol=1e-4):
     for ipt in range(N):
         dists.append(np.sqrt(np.dot(points[ipt], points[ipt])))
 
-    temp = np.array(dists)
-    temp.sort()
-    ind = np.argsort(dists)
+    # we need to round the distances to 8 decimals before sorting
+    # because 2 points might have "identical" distances to the origin,
+    # but they might differ on the 16 significant figure. As a result
+    # the argsort might flip their order even though the elements
+    # should not take over each other. By rounding them to 8
+    # significant figures, we somewhat guarantee that nodes that
+    # have similar distances to the origin dont get shuffled
+    # because of floating point errors
+    dists_rounded = np.around(dists, decimals=8)
+
+    # the "stable" sorting algorithm guarantees that entries
+    # with the same values dont overtake each other.
+    # The entries with identical distances are fully checked
+    # in the brute force check below.
+    ind = np.argsort(dists_rounded, kind="stable")
+
     i = 0
     cont = True
     newPoints = []


### PR DESCRIPTION
## Purpose

This PR addresses #89. The underlying cause was an argsort flipping the order of some entries due to the differences on the order of machine precision. By rounding the array to 8 significant figures before the sorting algorithm, we prevent this behavior. 

This might cause some existing runscripts to get a different ordering but as we saw with the test case that started failing, this means that these runscripts were susceptible to this issue anyways. If it shows up, this change will show up as a shuffled ordering of the FFD control points in shape variables. 

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
We'll see what azure says

## Checklist

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
