### PR TITLE
Fixed bug for composite DV

### DIFF
--- a/pygeo/__init__.py
+++ b/pygeo/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.10.0"
+__version__ = "1.10.1"
 
 from .pyNetwork import pyNetwork
 from .pyGeo import pyGeo

--- a/pygeo/parameterization/DVGeo.py
+++ b/pygeo/parameterization/DVGeo.py
@@ -1500,8 +1500,10 @@ class DVGeometry:
         if self.useComposite:
             dvDict = self.mapXDictToComp(dvDict)
 
-        for key, val in dvDict.items():
-            dvDict[key] = val.real
+        # cast DVs to real if we are in real mode
+        if not self.complex:
+            for key, val in dvDict.items():
+                dvDict[key] = val.real
 
         return dvDict
 

--- a/pygeo/parameterization/DVGeo.py
+++ b/pygeo/parameterization/DVGeo.py
@@ -1500,6 +1500,9 @@ class DVGeometry:
         if self.useComposite:
             dvDict = self.mapXDictToComp(dvDict)
 
+        for key, val in dvDict.items():
+            dvDict[key] = val.real
+
         return dvDict
 
     def extractCoef(self, axisID):

--- a/pygeo/parameterization/DVGeo.py
+++ b/pygeo/parameterization/DVGeo.py
@@ -1256,7 +1256,6 @@ class DVGeometry:
             The scaling applied to this DV, by default None
         """
         NDV = self.getNDV()
-        self.useComposite = True
         if self.name is not None:
             dvName = f"{self.name}_{dvName}"
         if u is not None:
@@ -1276,7 +1275,13 @@ class DVGeometry:
             # normalize the scaling
             scale = scale * (NDV / np.sum(scale))
 
-        self.DVComposite = geoDVComposite(dvName, NDV, u, scale=scale, s=s)
+        # map the initial design variable values
+        # we do this manually instead of calling self.mapVecToComp
+        # because self.DVComposite.u isn't available yet
+        values = u.T @ self.convertDictToSensitivity(self.getValues())
+
+        self.DVComposite = geoDVComposite(dvName, values, NDV, u, scale=scale, s=s)
+        self.useComposite = True
 
     def addGeoDVSectionLocal(self, *args, **kwargs):
         warnings.warn("addGeoDVSectionLocal will be deprecated, use addLocalSectionDV instead")

--- a/pygeo/parameterization/DVGeo.py
+++ b/pygeo/parameterization/DVGeo.py
@@ -1466,7 +1466,7 @@ class DVGeometry:
         """
         Generic routine to return the current set of design
         variables. Values are returned in a dictionary format
-        that would be suitable for a subsequent call to setValues()
+        that would be suitable for a subsequent call to :func:`setDesignVars`
 
         Returns
         -------

--- a/pygeo/parameterization/designVars.py
+++ b/pygeo/parameterization/designVars.py
@@ -302,13 +302,13 @@ class geoDVSectionLocal:
 
 
 class geoDVComposite(object):
-    def __init__(self, dvName, nVal, u, scale=1.0, s=None):
+    def __init__(self, dvName, value, nVal, u, scale=1.0, s=None):
         """
         Create a set of design variables which are linear combinations of existing design variables.
         """
         self.name = dvName
         self.nVal = nVal
-        self.value = np.zeros(self.nVal, "D")
+        self.value = value
         self.lower = None
         self.upper = None
         self.scale = convertTo1D(scale, self.nVal)


### PR DESCRIPTION
## Purpose
Apparently, I had hard-coded the initial DVs to zero. I didn't care at the time because in all my tests, the initial DVs happen to be zero anyways. But now I fixed it so it computes the correct initial DVs.

Also, I changed `getValues()` to return real values instead of complex. It didn't make sense to me to return any complex DVs, and I'm pretty sure the ESP/VSP versions will always return real values. The tests should all pass, and I'm somewhat confident in this change because `getValues()` is not really used internally in DVGeo. But maintainers please double check that this works.

## Expected time until merged
ASAP

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
N/A

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
