### PR TITLE
Fixing bug in local DVs

### DIFF
--- a/pygeo/parameterization/designVars.py
+++ b/pygeo/parameterization/designVars.py
@@ -70,7 +70,7 @@ class geoDVLocal(geoDV):
 
         N = len(axis)
         nVal = len(coefList) * N
-        super().__init__(name=name, value=np.zeros(nVal, "D"), nVal=nVal * N, lower=lower, upper=lower, scale=scale)
+        super().__init__(name=name, value=np.zeros(nVal, "D"), nVal=nVal, lower=lower, upper=upper, scale=scale)
 
         self.config = config
         self.coefList = np.zeros((self.nVal, 2), "intc")
@@ -155,7 +155,7 @@ class geoDVSpanwiseLocal(geoDV):
                 self.dv_to_coefs.append(loc_dv_to_coefs)
 
         nVal = len(self.dv_to_coefs)
-        super().__init__(name=name, value=np.zeros(nVal, "D"), nVal=nVal, lower=lower, upper=lower, scale=scale)
+        super().__init__(name=name, value=np.zeros(nVal, "D"), nVal=nVal, lower=lower, upper=upper, scale=scale)
 
         if "x" == axis.lower():
             self.axis = 0
@@ -229,12 +229,6 @@ class geoDVSectionLocal(geoDV):
         super().__init__(name=name, value=np.zeros(nVal, "D"), nVal=nVal, lower=None, upper=None, scale=scale)
 
         self.config = config
-        if lower is not None:
-            self.lower = convertTo1D(lower, self.nVal)
-        if upper is not None:
-            self.upper = convertTo1D(upper, self.nVal)
-        if scale is not None:
-            self.scale = convertTo1D(scale, self.nVal)
 
         self.sectionTransform = sectionTransform
         self.sectionLink = sectionLink


### PR DESCRIPTION
## Purpose
The changes in #130 to the DV classes introduced an issue that caused my cases and the tutorial wing and airfoil to not run, they exited immediately with SNOPT saying the problem was infeasible. I believe the issue is typos in `geoDVLocal` and `geoDVSpanwiseLocal`, which this should fix. 

The bigger question is why the MACH and pyGeo tests still passed with this issue and how tests could catch it.

## Expected time until merged
A day or two, there are only a few changed lines but someone who has cases that use different types of DVs might want to test with this to make sure everything is working.

## Type of change
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Without this change, running the tutorial scripts in Docker (I tried `u20-gcc-ompi-latest`) will result in an immediate exit with no apparent errors and a `10 14` code from SNOPT. 

## Checklist
- [X] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [X] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
