### PR TITLE
Bugfix for TriangulatedSurfaceConstraint

### DIFF
--- a/pygeo/constraints/areaConstraint.py
+++ b/pygeo/constraints/areaConstraint.py
@@ -278,7 +278,7 @@ class TriangulatedSurfaceConstraint(GeometricConstraint):
         )
         return deriv_output
 
-    def addConstraintsPyOpt(self, optProb):
+    def addConstraintsPyOpt(self, optProb, exclude_wrt=None):
         """
         Add the constraints to pyOpt, if the flag is set
         """


### PR DESCRIPTION
## Purpose
In #112, `DVCon.addConstraintsPyOpt()` started calling each `constraint.addConstraintsPyOpt()` with an extra parameter, `exclude_wrt`, but this was not added to `TriangulatedSurfaceConstraint.addConstraintsPyOpt()` so packing optimizations failed.

This function is covered by tests so I'm not sure why it's passing without the fix or how to catch this in the tests. 

The same function without the additional parameter is present in other constraints in pyGeo as well as pyTACS and baseclasses but I'm not sure if this fix is necessary there as well.

## Expected time until merged
Should be fast unless others need changed too or we need a test to cover this.

## Type of change
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Adding a triangulated surface constraint without this argument added raises the error `TypeError: addConstraintsPyOpt() got an unexpected keyword argument 'exclude_wrt'`, with this argument it works.

## Checklist
- [X] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [X] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
