### PR TITLE
fix camelcase to be consistent with adflow

### DIFF
--- a/pygeo/parameterization/DVGeo.py
+++ b/pygeo/parameterization/DVGeo.py
@@ -172,7 +172,7 @@ class DVGeometry(BaseDVGeometry):
         self.nPts = {}
 
         # dictionary to save any coordinate transformations we are given
-        self.coord_xfer = {}
+        self.coordXfer = {}
 
         # Derivatives of Xref and Coef provided by the parent to the
         # children
@@ -655,7 +655,7 @@ class DVGeometry(BaseDVGeometry):
 
         return nAxis
 
-    def addPointSet(self, points, ptName, origConfig=True, coord_xfer=None, **kwargs):
+    def addPointSet(self, points, ptName, origConfig=True, coordXfer=None, **kwargs):
         """
         Add a set of coordinates to DVGeometry
 
@@ -677,7 +677,7 @@ class DVGeometry(BaseDVGeometry):
             undeformed or deformed configuration. This should almost
             always be True except in circumstances when the user knows
             exactly what they are doing.
-        coord_xfer : function
+        coordXfer : function
             A callback function that performs a coordinate transformation
             between the DVGeo reference frame and any other reference
             frame. The DVGeo object uses this routine to apply the coordinate
@@ -688,26 +688,26 @@ class DVGeometry(BaseDVGeometry):
             the user to do whatever they want with the coordinate transformation.
             The function must have the first positional argument as the array that is
             (npt, 3) and the two keyword arguments that must be available are "mode"
-            ("fwd" or "bwd") and "apply_displacement" (True or False). This function
+            ("fwd" or "bwd") and "applyDisplacement" (True or False). This function
             can then be passed to DVGeo through something like ADflow, where the
             set DVGeo call can be modified as:
-            CFDSolver.setDVGeo(DVGeo, pointSetKwargs={"coord_xfer": coord_xfer})
+            CFDSolver.setDVGeo(DVGeo, pointSetKwargs={"coordXfer": coordXfer})
 
             An example function is as follows:
 
             .. code-block:: python
 
-                def coord_xfer(coords, mode="fwd", apply_displacement=True, **kwargs):
+                def coordXfer(coords, mode="fwd", applyDisplacement=True, **kwargs):
                     # given the (npt by 3) array "coords" apply the coordinate transformation.
                     # The "fwd" mode implies we go from DVGeo reference frame to the
                     # application, e.g. CFD, the "bwd" mode is the opposite;
                     # goes from the CFD reference frame back to the DVGeo reference frame.
-                    # the apply_displacement flag needs to be correctly implemented
+                    # the applyDisplacement flag needs to be correctly implemented
                     # by the user; the derivatives are also passed through this routine
                     # and they only need to be rotated when going between reference frames,
                     # and they should NOT be displaced.
 
-                    # In summary, all the displacements MUST be within the if apply_displacement == True
+                    # In summary, all the displacements MUST be within the if applyDisplacement == True
                     # checks, otherwise the derivatives will be wrong.
 
                     #  Example transfer: The CFD mesh
@@ -730,12 +730,12 @@ class DVGeometry(BaseDVGeometry):
                         coords_new = np.dot(coords, rot_mat)
 
                         # then the translation
-                        if apply_displacement:
+                        if applyDisplacement:
                             coords_new[:, 2] -= 5
                     elif mode == "bwd":
                         # apply the operations in reverse
                         coords_new = coords.copy()
-                        if apply_displacement:
+                        if applyDisplacement:
                             coords_new[:, 2] += 5
 
                         # and the rotation. note the rotation matrix is transposed
@@ -757,14 +757,14 @@ class DVGeometry(BaseDVGeometry):
         points = np.array(points).real.astype("d")
 
         # save the coordinate transformation info
-        if coord_xfer is not None:
-            self.coord_xfer[ptName] = coord_xfer
+        if coordXfer is not None:
+            self.coordXfer[ptName] = coordXfer
 
             # Also apply the first coordinate transformation while adding this ptset.
             # The child FFDs only interact with their parent FFD, and therefore,
             # do not need to access the coordinate transformation routine; i.e.
             # all transformations are applied once during the highest level DVGeo object.
-            points = self.coord_xfer[ptName](points, mode="bwd", apply_displacement=True)
+            points = self.coordXfer[ptName](points, mode="bwd", applyDisplacement=True)
 
         self.points[ptName] = points
 
@@ -1979,8 +1979,8 @@ class DVGeometry(BaseDVGeometry):
             # we only check if we need to apply the coordinate transformation
             # and move the pointset to the reference frame of the application,
             # if this is the last pygeo in the chain
-            if ptSetName in self.coord_xfer:
-                Xfinal = self.coord_xfer[ptSetName](Xfinal, mode="fwd", apply_displacement=True)
+            if ptSetName in self.coordXfer:
+                Xfinal = self.coordXfer[ptSetName](Xfinal, mode="fwd", applyDisplacement=True)
             return Xfinal
 
     def applyToChild(self, iChild):
@@ -2217,12 +2217,12 @@ class DVGeometry(BaseDVGeometry):
         N = dIdpt.shape[0]
 
         # apply the coordinate transformation on dIdpt if this pointset has it.
-        if ptSetName in self.coord_xfer:
+        if ptSetName in self.coordXfer:
             # loop over functions
             for ifunc in range(N):
                 # its important to remember that dIdpt are vector-like values,
                 # so we don't apply the transformations and only the rotations!
-                dIdpt[ifunc] = self.coord_xfer[ptSetName](dIdpt[ifunc], mode="bwd", apply_displacement=False)
+                dIdpt[ifunc] = self.coordXfer[ptSetName](dIdpt[ifunc], mode="bwd", applyDisplacement=False)
 
         # generate the total Jacobian self.JT
         self.computeTotalJacobian(ptSetName, config=config)
@@ -2326,10 +2326,10 @@ class DVGeometry(BaseDVGeometry):
             xsdot.reshape(len(xsdot) // 3, 3)
 
             # check if we have a coordinate transformation on this ptset
-            if ptSetName in self.coord_xfer:
+            if ptSetName in self.coordXfer:
                 # its important to remember that dIdpt are vector-like values,
                 # so we don't apply the transformations and only the rotations!
-                xsdot = self.coord_xfer[ptSetName](xsdot, mode="fwd", apply_displacement=False)
+                xsdot = self.coordXfer[ptSetName](xsdot, mode="fwd", applyDisplacement=False)
 
             # Maybe this should be:
             # xsdot = xsdot.reshape(len(xsdot)//3, 3)
@@ -2388,10 +2388,10 @@ class DVGeometry(BaseDVGeometry):
         else:
 
             # check if we have a coordinate transformation on this ptset
-            if ptSetName in self.coord_xfer:
+            if ptSetName in self.coordXfer:
                 # its important to remember that dIdpt are vector-like values,
                 # so we don't apply the transformations and only the rotations!
-                vec = self.coord_xfer[ptSetName](vec, mode="bwd", apply_displacement=False)
+                vec = self.coordXfer[ptSetName](vec, mode="bwd", applyDisplacement=False)
 
             xsdot = self.JT[ptSetName].dot(np.ravel(vec))
 

--- a/tests/reg_tests/test_DVGeometry.py
+++ b/tests/reg_tests/test_DVGeometry.py
@@ -1092,7 +1092,7 @@ class RegTestPyGeo(unittest.TestCase):
         DVGeo.addLocalDV("ydir", lower=-1.0, upper=1.0, axis="y", scale=1.0)
         DVGeo.addLocalDV("zdir", lower=-1.0, upper=1.0, axis="z", scale=1.0)
 
-        def coordXfer(coords, mode="fwd", apply_displacement=True):
+        def coordXfer(coords, mode="fwd", applyDisplacement=True):
             rot_mat = np.array(
                 [
                     [1, 0, 0],
@@ -1106,12 +1106,12 @@ class RegTestPyGeo(unittest.TestCase):
                 coords_new = np.dot(coords, rot_mat)
 
                 # then the translation
-                if apply_displacement:
+                if applyDisplacement:
                     coords_new[:, 2] -= 5.0
             elif mode == "bwd":
                 # apply the operations in reverse
                 coords_new = coords.copy()
-                if apply_displacement:
+                if applyDisplacement:
                     coords_new[:, 2] += 5.0
 
                 # and the rotation. note the rotation matrix is transposed

--- a/tests/reg_tests/test_DVGeometry.py
+++ b/tests/reg_tests/test_DVGeometry.py
@@ -1092,7 +1092,7 @@ class RegTestPyGeo(unittest.TestCase):
         DVGeo.addLocalDV("ydir", lower=-1.0, upper=1.0, axis="y", scale=1.0)
         DVGeo.addLocalDV("zdir", lower=-1.0, upper=1.0, axis="z", scale=1.0)
 
-        def coord_xfer(coords, mode="fwd", apply_displacement=True):
+        def coordXfer(coords, mode="fwd", apply_displacement=True):
             rot_mat = np.array(
                 [
                     [1, 0, 0],
@@ -1129,7 +1129,7 @@ class RegTestPyGeo(unittest.TestCase):
             ]
         )
 
-        DVGeo.addPointSet(test_points, "test", coord_xfer=coord_xfer)
+        DVGeo.addPointSet(test_points, "test", coordXfer=coordXfer)
 
         # check if we can query the same point back
         pts_new = DVGeo.update("test")


### PR DESCRIPTION
## Purpose

Changed instances of `coord_xfer` to `coordXfer` based on the changes requested in my ADflow PR: https://github.com/mdolab/adflow/pull/231

## Expected time until merged

1-2 days.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
