### PR TITLE
Efficient interior-only embedding

### DIFF
--- a/pygeo/pyBlock.py
+++ b/pygeo/pyBlock.py
@@ -858,7 +858,23 @@ class pyBlock:
         v0 = 0.0
         w0 = 0.0
 
+        if not checkErrors:
+            # Get the corners of the bounding box for this FFD
+            xMin, xMax = self.getBounds()
+
+            # Expand the bounds slightly in case a point lies on the boundary of the box
+            xMin -= embTol
+            xMax += embTol
+
         for i in range(N):
+
+            # If we are only interested in interior points, we check if this point is outside the bounding box.
+            # If it is outside the bounding box, we skip projecting this point to save time.
+            # A point can be inside the bounding box but still outside the FFD volumes.
+            # In this case, the point is identified as an exterior point by the projection, which is more costly.
+            if not checkErrors and (any(x0[i] < xMin) or any(x0[i] > xMax)):
+                continue
+
             for j in range(self.nVol):
                 iVol = volList[j]
                 u0, v0, w0, D0 = self.vols[iVol].projectPoint(x0[i], eps=eps, nIter=nIter)


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
I was running into long startup times when using child FFDs. The problem is that the embedding process for child FFDs can involve many points outside of the child FFD volume(s), and projecting these exterior points is expensive. In addition, projecting exterior points is more expensive with pySpline v1.5.2 than v1.5.1 because of the change in convergence criteria made in mdolab/pyspline#47.

To reduce the cost, I added a convex hull check for child FFDs (`interiorOnly=True`). One of the properties of B-splines is that they are contained within the convex hull of its control points. This means that if a point is outside the convex hull of the child FFD control points, we can skip the projection step because the point cannot be inside the FFD volume(s).

To test this, I timed the projection of a wing triangulated surface to a parent wing FFD and two child flap FFDs. The times in seconds are given in the table below:

|                 |                       | Wing | LE flap | TE flap |
|-----------------|-----------------------|------|---------|---------|
| pySpline v1.5.2 | Convex hull check     | 8.5  | 1.6     | 0.7     |
|                 | Bounding box check    | 8.5  | 19.4    | 1.7     |
|                 | No check              | 8.5  | 125.3   | 49.1    |
| pySpline v1.5.1 | Convex hull check     | 9.0  | 2.1     | 0.8     |
|                 | Bounding box check    | 8.9  | 5.3     | 0.9     |
|                 | No check              | 9.1  | 24.6    | 15.4    |

The projection times for the child FFDs are much faster with the convex hull check. The cost is similar now between pySpline versions because most exterior points are never passed to the projection routine.

I also initially tried a bounding box check, which you can see in the first commit on this branch. The bounding box is larger than the convex hull, so the projection is more expensive if the bounding box is not a close match for the FFD volume(s).

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
1 week

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->
One-level FFD behavior is unchanged. The current child FFD tests pass, including the box constraint tests, which test the edge case where the FFD volume and convex hull are coincident with points lying on surface of the FFD volume. I also tested this on more realistic wing and full configuration cases.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
