### PR TITLE
Fix matplotlib import in DVGeoCST

### DIFF
--- a/pygeo/constraints/DVCon.py
+++ b/pygeo/constraints/DVCon.py
@@ -1084,7 +1084,6 @@ class DVConstraints:
         DVGeoName="default",
         compNames=None,
     ):
-
         """This is similar to addLocationConstraints1D except that the actual
         poly line is determined by first projecting points on to the
         surface in a similar manner as addConstraints1D, and then
@@ -2181,7 +2180,6 @@ class DVConstraints:
         DVGeoName="default",
         compNames=None,
     ):
-
         """Code for doing landing gear post constraints on the fly in an
         optimization. As it turns out, this is a critical constraint
         for wing-mounted landing gear and high-aspect ratio swept
@@ -3204,7 +3202,6 @@ class DVConstraints:
         )
 
     def _checkDVGeo(self, name="default"):
-
         """check if DVGeo exists"""
         if name not in self.DVGeometries.keys():
             raise Error(
@@ -3262,7 +3259,6 @@ class DVConstraints:
             te_span_s = np.array([])
 
             for i in range(numSegments):
-
                 # Only include the endpoint if this is the last segment to avoid double counting points
                 if i == numSegments - 1:
                     endpoint = True

--- a/pygeo/constraints/baseConstraint.py
+++ b/pygeo/constraints/baseConstraint.py
@@ -185,7 +185,6 @@ class LinearConstraint:
         # Local Shape Variables
         for key in self.DVGeo.DV_listLocal:
             if self.config is None or self.config in self.DVGeo.DV_listLocal[key].config:
-
                 # end for (indSet loop)
                 cons = self.DVGeo.DV_listLocal[key].mapIndexSets(self.indSetA, self.indSetB)
                 ncon = len(cons)
@@ -206,7 +205,6 @@ class LinearConstraint:
         # Section local shape variables
         for key in self.DVGeo.DV_listSectionLocal:
             if self.config is None or self.config in self.DVGeo.DV_listSectionLocal[key].config:
-
                 # end for (indSet loop)
                 cons = self.DVGeo.DV_listSectionLocal[key].mapIndexSets(self.indSetA, self.indSetB)
                 ncon = len(cons)
@@ -227,7 +225,6 @@ class LinearConstraint:
         # Section local shape variables
         for key in self.DVGeo.DV_listSpanwiseLocal:
             if self.config is None or self.config in self.DVGeo.DV_listSpanwiseLocal[key].config:
-
                 # end for (indSet loop)
                 cons = self.DVGeo.DV_listSpanwiseLocal[key].mapIndexSets(self.indSetA, self.indSetB)
                 ncon = len(cons)

--- a/pygeo/constraints/gearPostConstraint.py
+++ b/pygeo/constraints/gearPostConstraint.py
@@ -46,7 +46,6 @@ class GearPostConstraint(GeometricConstraint):
         self.D0 = np.linalg.norm(self.coords[0] - self.coords[1])
 
     def evalFunctions(self, funcs, config):
-
         # Update the gear post locations
         self.coords = self.DVGeo.update(self.name, config=config)
 
@@ -79,7 +78,6 @@ class GearPostConstraint(GeometricConstraint):
         """
         nDV = self.DVGeo.getNDV()
         if nDV > 0:
-
             wfuncs = {}
             self.wimpress.evalFunctions(wfuncs)
 

--- a/pygeo/geo_utils/dcel.py
+++ b/pygeo/geo_utils/dcel.py
@@ -38,7 +38,6 @@ class DCELEdge:
         self.con = [v1, v2]
 
     def __repr__(self):
-
         str1 = f"v1: {self.v1[0]:f} {self.v1[1]:f}\nv2: {self.v2[0]:f} {self.v2[1]:f}"
         return str1
 
@@ -128,7 +127,6 @@ class DCELFace:
         self.centroid = center / counter
 
     def calcSpatialCentroid(self):
-
         h = self.wedge
         center = np.zeros(3)
         center += h.origin.X
@@ -223,7 +221,6 @@ class DCEL:
             multCheck = mult < 2
 
             if np.any(multCheck):
-
                 # We need to do a couple of things:
                 # 1. The bad vertices need to be removed from the vertex list
                 # 2. Remaning vertices must be renamed
@@ -270,7 +267,6 @@ class DCEL:
         appendCount = 0
 
         for e in self.el:
-
             h1 = DCELHedge(self.vertices[e.con[0]], self.vertices[e.con[1]], e.PID, e.uv, e.tag)
             h2 = DCELHedge(self.vertices[e.con[1]], self.vertices[e.con[0]], e.PID, e.uv, e.tag)
 
@@ -326,7 +322,6 @@ class DCEL:
                 self.faces[i].tag = self.faceInfo[i]
 
     def writeTecplot(self, fileName):
-
         f = open(fileName, "w")
         f.write('VARIABLES = "X","Y"\n')
         for i in range(len(self.el)):
@@ -395,7 +390,6 @@ class DCEL:
         return len(self.hedges) // 2
 
     def saveDCEL(self, fileName):
-
         f = open(fileName, "w")
         f.write("%d %d %d\n" % (self.nvertices(), self.nedges(), self.nfaces()))
         for i in range(self.nvertices()):
@@ -448,7 +442,6 @@ class DCEL:
         f.close()
 
     def loadDCEL(self, fileName):
-
         f = open(fileName)
         # Read sizes
         tmp = f.readline().split()

--- a/pygeo/geo_utils/ffd_generation.py
+++ b/pygeo/geo_utils/ffd_generation.py
@@ -160,7 +160,6 @@ def write_wing_FFD_file(fileName, slices, N0, N1, N2, axes=None, dist=None):
 
 
 def createFittedWingFFD(surf, surfFormat, outFile, leList, teList, nSpan, nChord, absMargins, relMargins, liftIndex):
-
     """
     Generates a wing FFD with chordwise points that follow the airfoil geometry.
 

--- a/pygeo/geo_utils/node_edge_face.py
+++ b/pygeo/geo_utils/node_edge_face.py
@@ -127,7 +127,6 @@ def setNodeValue(arr, value, nodeIndex):
 
 
 def setEdgeValue(arr, values, edgeDir, edgeIndex):
-
     if edgeDir == -1:  # Reverse values
         values = values[::-1]
 
@@ -162,7 +161,6 @@ def setEdgeValue(arr, values, edgeDir, edgeIndex):
 
 
 def setFaceValue(arr, values, faceDir, faceIndex):
-
     # Orient the array first according to the dir:
 
     values = orientArray(faceDir, values)
@@ -184,7 +182,6 @@ def setFaceValue(arr, values, faceDir, faceIndex):
 
 
 def setFaceValue2(arr, values, faceDir, faceIndex):
-
     # Orient the array first according to the dir:
 
     values = orientArray(faceDir, values)
@@ -264,7 +261,6 @@ class EdgeCmpObject:
         return "Node1: %d Node2: %d MidPt: %f %f %f" % (self.n1, self.n2, self.midPt[0], self.midPt[1], self.midPt[2])
 
     def __lt__(self, other):
-
         if self.n1 != other.n1:
             return self.n1 < other.n1
 
@@ -316,7 +312,6 @@ class FaceCmpObject:
         )
 
     def __lt__(self, other):
-
         if self.n1 != other.n1:
             return self.n1 < other.n1
 

--- a/pygeo/geo_utils/pointselect.py
+++ b/pygeo/geo_utils/pointselect.py
@@ -5,7 +5,6 @@ from pyspline.utils import bilinearSurface
 
 class PointSelect:
     def __init__(self, psType, *args, **kwargs):
-
         """Initialize a control point selection class. There are several ways
         to initialize this class depending on the 'type' qualifier:
 
@@ -121,12 +120,10 @@ class PointSelect:
                 raise ValueError("The indices provided to pointSelect are not unique.")
 
         elif psType == "ijkBounds":
-
             self.ijkBounds = kwargs["ijkBounds"]  # Store the ijk bounds dictionary
             self.type = "ijkBounds"
 
     def getPoints(self, points):
-
         """Take in a list of points and return the ones that statify
         the point select class."""
         ptList = []
@@ -152,7 +149,6 @@ class PointSelect:
         return ptList, indList
 
     def getPoints_ijk(self, DVGeo):
-
         """Receives a DVGeo object (with an embedded FFD) and uses the ijk bounds specified in the initialization to extract
         the corresponding indices.
 
@@ -165,7 +161,6 @@ class PointSelect:
 
         # Loop over every dictionary entry to get cooresponding indices
         for iVol in self.ijkBounds:
-
             # Get current bounds
             ilow = self.ijkBounds[iVol][0][0]
             ihigh = self.ijkBounds[iVol][0][1]

--- a/pygeo/geo_utils/projection.py
+++ b/pygeo/geo_utils/projection.py
@@ -107,7 +107,6 @@ def projectNodePID(pt, upVec, p0, v1, v2, uv0, uv1, uv2, PID):
         secondS = ss[1]
 
         if np.dot(first - pt, upVec) >= np.dot(second - pt, upVec):
-
             return (
                 [first, firstPatchID, firstU, firstV, firstS],
                 [second, secondPatchID, secondU, secondV, secondS],
@@ -126,7 +125,6 @@ def projectNodePID(pt, upVec, p0, v1, v2, uv0, uv1, uv2, PID):
 
 
 def projectNodePIDPosOnly(pt, upVec, p0, v1, v2, uv0, uv1, uv2, PID):
-
     # Get the bounds of the geo object so we know what to scale by
 
     fail = 0

--- a/pygeo/geo_utils/split_quad.py
+++ b/pygeo/geo_utils/split_quad.py
@@ -182,7 +182,6 @@ def tfi_2d(e0, e1, e2, e3):
     try:
         X = tfi2d(e0.T, e1.T, e2.T, e3.T).T
     except Exception:
-
         Nu = len(e0)
         Nv = len(e2)
         if Nu != len(e1):

--- a/pygeo/mphys/mphys_dvgeo.py
+++ b/pygeo/mphys/mphys_dvgeo.py
@@ -10,7 +10,6 @@ from .. import DVConstraints, DVGeometry, DVGeometryESP, DVGeometryVSP
 # class that actually calls the dvgeometry methods
 class OM_DVGEOCOMP(om.ExplicitComponent):
     def initialize(self):
-
         self.options.declare("file", default=None)
         self.options.declare("type", default=None)
         self.options.declare("options", default=None)
@@ -294,7 +293,6 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
         ni = len(list(d_inputs.keys()))
 
         if mode == "rev" and ni > 0:
-
             # this flag will be set to True after every compute call.
             # if it is true, we assume the design has changed so we re-run the sensitivity update
             # there can be hundreds of calls to this routine due to thickness constraints,
@@ -331,7 +329,6 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
 
                     # global_all_zeros is a numpy array of size 1
                     if not global_all_zeros[0]:
-
                         # TODO totalSensitivityTransProd is broken. does not work with zero surface nodes on a proc
                         # xdot = self.DVGeo.totalSensitivityTransProd(dout, ptSetName)
                         xdot = self.DVGeo.totalSensitivity(dout, ptSetName)

--- a/pygeo/parameterization/DVGeo.py
+++ b/pygeo/parameterization/DVGeo.py
@@ -108,7 +108,7 @@ class DVGeometry(BaseDVGeometry):
         # which we now check in kwargs and overwrite
         if "complex" in kwargs:
             isComplex = kwargs.pop("complex")
-            warnings.warn("The keyword argument 'complex' is deprecated, use 'isComplex' instead.")
+            warnings.warn("The keyword argument 'complex' is deprecated, use 'isComplex' instead.", stacklevel=2)
 
         # Coefficient rotation matrix dict for Section Local variables
         self.coefRotM = {}
@@ -2708,7 +2708,7 @@ class DVGeometry(BaseDVGeometry):
             # add the linear DV constraints that replace the existing bounds!
             # Note that we assume all DVs are added here, i.e. no ignoreVars or any of the vars = False
             if len(ignoreVars) != 0:
-                warnings.warn("Use of ignoreVars is incompatible with composite DVs")
+                warnings.warn("Use of ignoreVars is incompatible with composite DVs", stacklevel=2)
             lb = {}
             ub = {}
             for lst in varLists:

--- a/pygeo/parameterization/DVGeo.py
+++ b/pygeo/parameterization/DVGeo.py
@@ -1110,7 +1110,6 @@ class DVGeometry(BaseDVGeometry):
 
         volDVMap = []
         for ivol in volList:
-
             spanIdx = ijk_2_idx[spanIndex[ivol]]
             lIndex = self.FFD.topo.lIndex[ivol]
 
@@ -2387,7 +2386,6 @@ class DVGeometry(BaseDVGeometry):
         if self.JT[ptSetName] is None:
             xsdot = np.zeros((0, 3))
         else:
-
             # check if we have a coordinate transformation on this ptset
             if ptSetName in self.coordXfer:
                 # its important to remember that dIdpt are vector-like values,
@@ -2521,7 +2519,6 @@ class DVGeometry(BaseDVGeometry):
 
             # Add in child portion
             for iChild in range(len(self.children)):
-
                 # Reset control points on child for child link derivatives
                 self.applyToChild(iChild)
                 self.children[iChild].computeTotalJacobian(ptSetName, config=config)
@@ -2898,6 +2895,7 @@ class DVGeometry(BaseDVGeometry):
             If scalar, it is applied across each surface. If list, the length must match the
             number of surfaces in the object and corresponding entries are matched with surfaces
         """
+
         # Function to check if value matches a knot point
         # (set to 1e-12 to match pySpline mult. tolerance)
         def check_mult(val, knots):
@@ -3216,7 +3214,6 @@ class DVGeometry(BaseDVGeometry):
             if self.axis[key]["axis"] is None:
                 tmpIDs, tmpS0 = self.refAxis.projectPoints(curPts, curves=[curveID])
             else:
-
                 if isinstance(self.axis[key]["axis"], str) and len(self.axis[key]["axis"]) == 1:
                     # The axis can be a string of length one.
                     # If so, we follow the ray projection approach.
@@ -3479,13 +3476,11 @@ class DVGeometry(BaseDVGeometry):
         return self.nDVG_count, self.nDVL_count, self.nDVSL_count, self.nDVSW_count
 
     def _update_deriv(self, iDV=0, oneoverh=1.0 / 1e-40, config=None, localDV=False):
-
         """Copy of update function for derivative calc"""
         new_pts = np.zeros((self.nPtAttach, 3), "D")
 
         # Step 1: Call all the design variables IFF we have ref axis:
         if len(self.axis) > 0:
-
             # Recompute changes due to global dvs at current point + h
             self.updateCalculations(new_pts, isComplex=True, config=config)
 
@@ -3505,7 +3500,6 @@ class DVGeometry(BaseDVGeometry):
 
             # set the forward effect of the global design vars in each child
             for iChild in range(len(self.children)):
-
                 # get the derivative of the child axis and control points wrt the parent
                 # control points
                 dXrefdCoef = self.FFD.embeddedVolumes["child%d_axis" % (iChild)].dPtdCoef
@@ -3543,7 +3537,6 @@ class DVGeometry(BaseDVGeometry):
         return new_pts
 
     def _update_deriv_cs(self, ptSetName, config=None):
-
         """
         A version of the update_deriv function specifically for use
         in the computeTotalJacobianCS function."""
@@ -3577,7 +3570,6 @@ class DVGeometry(BaseDVGeometry):
 
         # Step 1: Call all the design variables IFF we have ref axis:
         if len(self.axis) > 0:
-
             # Compute changes due to global design vars
             self.updateCalculations(new_pts, isComplex=True, config=config)
 
@@ -3857,7 +3849,6 @@ class DVGeometry(BaseDVGeometry):
                 ):
                     nVal = self.DV_listGlobal[key].nVal
                     for j in range(nVal):
-
                         refVal = self.DV_listGlobal[key].value[j]
 
                         self.DV_listGlobal[key].value[j] += h
@@ -4025,7 +4016,6 @@ class DVGeometry(BaseDVGeometry):
                         # Jacobian[rows, iDVSectionLocal] += R.dot(T.dot(inFrame))
                         Jacobian[coef * 3 : (coef + 1) * 3, iDVSectionLocal] += R.dot(T.dot(inFrame))
                         for iChild in range(len(self.children)):
-
                             dXrefdCoef = self.FFD.embeddedVolumes["child%d_axis" % (iChild)].dPtdCoef
                             dCcdCoef = self.FFD.embeddedVolumes["child%d_coef" % (iChild)].dPtdCoef
 
@@ -4089,7 +4079,6 @@ class DVGeometry(BaseDVGeometry):
                     or config is None
                     or any(c0 == config for c0 in self.DV_listLocal[key].config)
                 ):
-
                     self.DV_listLocal[key](self.FFD.coef, config)
 
                     nVal = self.DV_listLocal[key].nVal
@@ -4327,7 +4316,6 @@ class DVGeometry(BaseDVGeometry):
 
         for key in self.DV_listGlobal:
             for j in range(self.DV_listGlobal[key].nVal):
-
                 print("========================================")
                 print("      GlobalVar(%s), Value(%d)" % (key, j))
                 print("========================================")
@@ -4347,7 +4335,6 @@ class DVGeometry(BaseDVGeometry):
                 deriv = (coordsph - coords0) / h
 
                 for ii in range(len(deriv)):
-
                     relErr = (deriv[ii] - Jac[DVCountGlob, ii]) / (1e-16 + Jac[DVCountGlob, ii])
                     absErr = deriv[ii] - Jac[DVCountGlob, ii]
 
@@ -4359,7 +4346,6 @@ class DVGeometry(BaseDVGeometry):
 
         for key in self.DV_listLocal:
             for j in range(self.DV_listLocal[key].nVal):
-
                 print("========================================")
                 print("      LocalVar(%s), Value(%d)           " % (key, j))
                 print("========================================")
@@ -4389,7 +4375,6 @@ class DVGeometry(BaseDVGeometry):
 
         for key in self.DV_listSectionLocal:
             for j in range(self.DV_listSectionLocal[key].nVal):
-
                 print("========================================")
                 print("   SectionLocalVar(%s), Value(%d)       " % (key, j))
                 print("========================================")
@@ -4419,7 +4404,6 @@ class DVGeometry(BaseDVGeometry):
 
         for key in self.DV_listSpanwiseLocal:
             for j in range(self.DV_listSpanwiseLocal[key].nVal):
-
                 print("========================================")
                 print("   SpanwiseLocalVar(%s), Value(%d)       " % (key, j))
                 print("========================================")

--- a/pygeo/parameterization/DVGeoAxi.py
+++ b/pygeo/parameterization/DVGeoAxi.py
@@ -205,7 +205,6 @@ class DVGeometryAxi(DVGeometry):
     """
 
     def __init__(self, fileName, center, collapse_into, *args, isComplex=False, child=False, **kwargs):
-
         self.axiTransforms = OrderedDict()  # TODO: Why is this ordered?
 
         # FIXME: for backwards compatibility we still allow the argument complex=True/False
@@ -247,7 +246,6 @@ class DVGeometryAxi(DVGeometry):
         super().addPointSet(xform.c_pts, ptName, origConfig, **kwargs)
 
     def update(self, ptSetName, childDelta=True, config=None):
-
         new_c_pts = super().update(ptSetName, childDelta, config)
 
         xform = self.axiTransforms[ptSetName]

--- a/pygeo/parameterization/DVGeoAxi.py
+++ b/pygeo/parameterization/DVGeoAxi.py
@@ -40,7 +40,7 @@ class _AxiTransform:
         # which we now check in kwargs and overwrite
         if "complex" in kwargs:
             isComplex = kwargs.pop("complex")
-            warnings.warn("The keyword argument 'complex' is deprecated, use 'isComplex' instead.")
+            warnings.warn("The keyword argument 'complex' is deprecated, use 'isComplex' instead.", stacklevel=2)
 
         self.complex = isComplex
 
@@ -211,7 +211,7 @@ class DVGeometryAxi(DVGeometry):
         # which we now check in kwargs and overwrite
         if "complex" in kwargs:
             isComplex = kwargs.pop("complex")
-            warnings.warn("The keyword argument 'complex' is deprecated, use 'isComplex' instead.")
+            warnings.warn("The keyword argument 'complex' is deprecated, use 'isComplex' instead.", stacklevel=2)
 
         super().__init__(fileName, isComplex=isComplex, child=child, *args, **kwargs)
 

--- a/pygeo/parameterization/DVGeoCST.py
+++ b/pygeo/parameterization/DVGeoCST.py
@@ -25,7 +25,7 @@ try:
     import matplotlib.pyplot as plt
 
     pltImport = True
-except ModuleNotFoundError:
+except ImportError:
     pltImport = False
 
 # Local modules

--- a/pygeo/parameterization/DVGeoMulti.py
+++ b/pygeo/parameterization/DVGeoMulti.py
@@ -315,10 +315,8 @@ class DVGeometryMulti:
         # before we do anything, we need to create surface ADTs
         # for which the user provided triangulated meshes
         for comp in compNames:
-
             # check if we have a trimesh for this component
             if self.comps[comp].triMesh:
-
                 # Now we build the ADT using pySurf
                 # Set bounding box for new tree
                 BBox = np.zeros((2, 3))
@@ -356,7 +354,6 @@ class DVGeometryMulti:
 
         # we now need to create the component mapping information
         for i in range(self.points[ptName].nPts):
-
             # initial flags
             inFFD = False
             proj = False
@@ -364,7 +361,6 @@ class DVGeometryMulti:
 
             # loop over components and check if this point is in a single BBox
             for comp in compNames:
-
                 # apply a small tolerance for the bounding box in case points are coincident with the FFD
                 boundTol = 1e-16
                 xMin = self.comps[comp].xMin
@@ -378,7 +374,6 @@ class DVGeometryMulti:
                     and xMin[1] < points[i, 1] < xMax[1]
                     and xMin[2] < points[i, 2] < xMax[2]
                 ):
-
                     # add this component to the projection list
                     projList.append(comp)
 
@@ -393,7 +388,6 @@ class DVGeometryMulti:
 
             # project this point to components, we need to set inComp string
             if proj:
-
                 # set a high initial distance
                 dMin2 = 1e10
 
@@ -401,7 +395,6 @@ class DVGeometryMulti:
                 for comp in compNames:
                     # check if this component is in the projList
                     if comp in projList:
-
                         # check if we have an ADT:
                         if self.comps[comp].triMesh:
                             # Initialize reference values (see explanation above)
@@ -894,7 +887,6 @@ class DVGeometryMulti:
         dvOffset = 0
         # we need to call computeTotalJacobian from all comps and get the jacobians for this pointset
         for comp in self.compNames:
-
             # number of design variables
             nDVComp = self.comps[comp].DVGeo.getNDV()
 
@@ -919,7 +911,6 @@ class DVGeometryMulti:
 
 class component:
     def __init__(self, name, DVGeo, nodes, triConn, triConnStack, barsConn, xMin, xMax):
-
         # save the info
         self.name = name
         self.DVGeo = DVGeo
@@ -1170,7 +1161,6 @@ class CompIntersection:
         self.seam = self._getIntersectionSeam(comm)
 
     def addPointSet(self, pts, ptSetName, compMap, comm):
-
         # Figure out which points this intersection object has to deal with
 
         # Use pySurf to project the point on curve
@@ -1216,7 +1206,6 @@ class CompIntersection:
             halfdStar = dStar / 2.0
 
             if d[i] < dStar:
-
                 # Compute the factor
                 if d[i] < halfdStar:
                     factor = 0.5 * (d[i] / halfdStar) ** 3
@@ -1240,7 +1229,6 @@ class CompIntersection:
             }
 
             if nPoints > 0 and self.excludeSurfaces:
-
                 # Associate points with the excluded surfaces
                 for surface in self.excludeSurfaces:
                     surfaceEps = self.excludeSurfaces[surface]
@@ -1282,7 +1270,6 @@ class CompIntersection:
 
             # maybe we can do this vectorized
             for ind in indices:
-
                 # check compA
                 if ind in compMap[self.compA.name]:
                     flagA = True
@@ -1315,7 +1302,6 @@ class CompIntersection:
 
             # if we include the feature curves in the warping, we also need to project the added points to the intersection and feature curves and determine how the points map to the curves
             if self.incCurves:
-
                 # convert the list to an array
                 # we specify the dtype because numpy cannot know the type when 'indices' is empty
                 indices = np.array(indices, dtype="intc")
@@ -1368,7 +1354,6 @@ class CompIntersection:
                 # now loop over feature curves and use the epsilon that each curve has
                 # to determine which points maps to which curve
                 for curveName in allCurves:
-
                     # get the epsilon for this curve
                     # we map the points closer than eps to this curve
                     eps = self.curveEpsDict[curveName]
@@ -1424,7 +1409,6 @@ class CompIntersection:
 
                 # we need to figure out if we have any points mapped to curves on comp A
                 for curveName in allCurves:
-
                     # get the indices mapped to this curve, on this proc
                     idxs = self.curveProjIdx[ptSetName][curveName]
 
@@ -1439,7 +1423,6 @@ class CompIntersection:
                     self.nCurvePts[ptSetName][curveName] = nPtsTotal
 
     def update(self, ptSetName, delta):
-
         """Update the delta in ptSetName with our correction. The delta need
         to be supplied as we will be changing it and returning them
         """
@@ -1593,7 +1576,6 @@ class CompIntersection:
             seamBar += self.seamBarProj[ptSetName]
 
         for i in range(len(factors)):
-
             # j is the index of the point in the full set we are working with.
             j = indices[i]
 
@@ -1629,7 +1611,6 @@ class CompIntersection:
             evalDiff = eval1 - eval2
 
             for k in range(dIdPt.shape[0]):
-
                 # This is the local seed (well the 3 seeds for the point)
                 localVal = dIdPt[k, j, :] * (1 - factors[i])
 
@@ -1692,7 +1673,6 @@ class CompIntersection:
 
         # loop over the feature curves that we need to project
         for curveName in self.featureCurveNames:
-
             # get the indices of points we need to project
             idx = self.curveProjIdx[ptSetName][curveName]
 
@@ -1904,7 +1884,6 @@ class CompIntersection:
 
         # call the actual driver with the info to prevent code multiplication
         if flagA:
-
             # Project remaining points to the component as a whole
             indAComp = self.projData[ptSetName]["compA"]["indAComp"]
             if indAComp:
@@ -1952,7 +1931,6 @@ class CompIntersection:
 
         # do the same for B
         if flagB:
-
             indBComp = self.projData[ptSetName]["compB"]["indBComp"]
             if indBComp:
                 dIdptB = dIdpt[:, indBComp]
@@ -2065,14 +2043,12 @@ class CompIntersection:
 
         # loop over the curves
         for curveName in self.featureCurveNames:
-
             # sizes and displacements for this curve
             sizes = self.curveProjData[ptSetName][curveName]["sizes"]
             disp = self.curveProjData[ptSetName][curveName]["disp"]
 
             # we get the seeds from compA seeds
             if curveName in self.curvesOnA:
-
                 if flagA:
                     # contribution on this proc
                     deltaBar = deltaA_b[:, disp[rank] : disp[rank] + sizes[rank]].copy()
@@ -2086,7 +2062,6 @@ class CompIntersection:
 
             # seeds from compB
             elif curveName in self.curvesOnB:
-
                 if flagB:
                     # contribution on this proc
                     deltaBar = deltaB_b[:, disp[rank] : disp[rank] + sizes[rank]].copy()
@@ -2124,7 +2099,6 @@ class CompIntersection:
 
                 # run the bwd projection for everyfunction
                 for k in range(N):
-
                     # contribution from delta
                     xyzProjb = deltaBar[k].copy()
 
@@ -2222,7 +2196,6 @@ class CompIntersection:
             return
 
         for j in indices:
-
             # point coordinates with the baseline design
             # this is the point we will warp
             ptCoords = pts0[j]
@@ -2241,7 +2214,6 @@ class CompIntersection:
             ptsNew[j] = ptsNew[j] + interp
 
     def _warpSurfPts_b(self, dIdPt, pts0, indices, curvePtCoords):
-
         # seeds for delta
         deltaBar = np.zeros((dIdPt.shape[0], curvePtCoords.shape[0], 3))
 
@@ -2250,9 +2222,7 @@ class CompIntersection:
             return deltaBar
 
         for k in range(dIdPt.shape[0]):
-
             for j in indices:
-
                 # point coordinates with the baseline design
                 # this is the point we will warp
                 ptCoords = pts0[j]
@@ -2345,7 +2315,6 @@ class CompIntersection:
         return xyzProj
 
     def _projectToComponent_b(self, dIdpt, comp, projDict, surface=None):
-
         # We build an ADT for this component using pySurf
         # Set bounding box for new tree
         BBox = np.zeros((2, 3))
@@ -2478,7 +2447,6 @@ class CompIntersection:
 
         # Retrieve results from Fortran if we have an intersection
         if np.max(arraySizes[1:]) > 0:
-
             # Second Fortran call to retrieve data from the CGNS file.
             intersectionArrays = self.intersectionAPI.retrievedata(*arraySizes)
 
@@ -2556,14 +2524,12 @@ class CompIntersection:
 
         # loop over the feature curves
         for curveName in self.featureCurveNames:
-
             # we need to initialize the dictionary here
             # to get the intermediate output from mindistancecurve call
             self.seamDict[curveName] = {}
 
             # if this curve is on compB, we use it to track intersection features
             if curveName in self.compB.barsConn and curveName not in self.remeshAll:
-
                 # get the curve connectivity
                 curveConn = self.compB.barsConn[curveName]
 
@@ -2722,7 +2688,6 @@ class CompIntersection:
 
         # we need to re-mesh feature curves if the user wants...
         if self.incCurves:
-
             # we need to set up some variables
             if firstCall:
                 self.nNodeFeature = {}
@@ -2733,7 +2698,6 @@ class CompIntersection:
 
             # loop over each curve, figure out what nodes get re-meshed, re-mesh, and append to seam...
             for curveName in self.featureCurveNames:
-
                 # figure out which comp owns this curve...
                 if curveName in self.compB.barsConn:
                     curveComp = self.compB
@@ -2953,7 +2917,6 @@ class CompIntersection:
 
         # check if we included feature curves
         if self.incCurves:
-
             # offset for the derivative seeds for this curve
             iBeg = 0
 
@@ -3079,7 +3042,6 @@ class CompIntersection:
                     curveProjb[curveName] = np.zeros((N, 3))
 
                     for ii in range(N):
-
                         # the only nonzero seed is indexed by argmin dist2
                         xyzProjb[np.argmin(dist2)] = projb[ii].copy()
 

--- a/pygeo/parameterization/DVGeoVSP.py
+++ b/pygeo/parameterization/DVGeoVSP.py
@@ -291,14 +291,12 @@ class DVGeometryVSP(DVGeoSketch):
                 # Just pick the one that yields the smallest d
                 gind = 0
                 for gid in self.allComps:
-
                     # only project if the point is in the bounding box of the geometry
                     if (
                         (self.bbox[gid][0, 0] < points[i, 0] < self.bbox[gid][0, 1])
                         and (self.bbox[gid][1, 0] < points[i, 1] < self.bbox[gid][1, 1])
                         and (self.bbox[gid][2, 0] < points[i, 2] < self.bbox[gid][2, 1])
                     ):
-
                         # project the point onto the VSP geometry
                         dNew, rout, sout, tout = openvsp.FindRST(gid, 0, pnt)
 

--- a/pygeo/parameterization/designVars.py
+++ b/pygeo/parameterization/designVars.py
@@ -198,9 +198,7 @@ class geoDVSpanwiseLocal(geoDV):
 
             # Note: We are doing inefficient double looping here
             for idx_dv, coefs in enumerate(self.dv_to_coefs):
-
                 for coef in coefs:
-
                     if coef == indSetA[j]:
                         up = idx_dv
                     if coef == indSetB[j]:

--- a/pygeo/pyBlock.py
+++ b/pygeo/pyBlock.py
@@ -51,7 +51,6 @@ class pyBlock:
     """
 
     def __init__(self, initType, fileName=None, FFD=False, symmPlane=None, kmax=4, **kwargs):
-
         self.initType = initType
         self.FFD = False
         self.topo = None  # The topology of the volumes/surface
@@ -425,7 +424,6 @@ class pyBlock:
             for ivol in range(self.nVol):
                 for iedge in range(12):
                     if self.topo.edges[self.topo.edgeLink[ivol][iedge]].dg == idg:
-
                         if self.topo.edgeDir[ivol][iedge] == -1:
                             flip.append(True)
                         else:
@@ -452,7 +450,6 @@ class pyBlock:
             for ivol in range(self.nVol):
                 for iedge in range(12):
                     if self.topo.edges[self.topo.edgeLink[ivol][iedge]].dg == idg:
-
                         if iedge in [0, 1, 4, 5]:
                             if flip[counter]:
                                 self.vols[ivol].tu = newKnotVecFlip.copy()
@@ -878,7 +875,6 @@ class pyBlock:
             isInsideHull = np.all(distanceToPlanes <= eps, axis=1)
 
         for i in range(N):
-
             # Do not project this point if it is outside the convex hull and we are only interested in interior points
             if interiorOnly and not isInsideHull[i]:
                 continue

--- a/pygeo/pyGeo.py
+++ b/pygeo/pyGeo.py
@@ -598,7 +598,6 @@ class pyGeo:
         print("Computing Tip surfaces ...")
         # # Add on additional surfaces if required for a rounded pinch tip
         if tip == "rounded":
-
             # Generate the midpoint of the coefficients
             midPts = np.zeros([ncoef, 3])
             upVec = np.zeros([ncoef, 3])
@@ -975,7 +974,6 @@ class pyGeo:
         edgeLabels=False,
         nodeLabels=False,
     ):
-
         """Write the pyGeo Object to Tecplot dat file
 
         Parameters

--- a/pygeo/pyNetwork.py
+++ b/pygeo/pyNetwork.py
@@ -413,7 +413,6 @@ class pyNetwork:
         for i in range(len(curves)):
             icurve = curves[i]
             for j in range(N):
-
                 # we need to initialize a pySurface object for this point
                 # the point is perturbed in dir 1 and dir2 to get 4 corners of the plane
                 point = points[j]

--- a/pygeo/topology.py
+++ b/pygeo/topology.py
@@ -103,7 +103,6 @@ class Topology:
         self.nEnt = None
 
     def _calcDGs(self, edges, edgeLink, edgeLinkSorted, edgeLinkInd):
-
         dgCounter = -1
         for i in range(self.nEdge):
             if edges[i][2] == -1:  # Not set yet
@@ -262,7 +261,6 @@ class Topology:
             f.write("\n")
 
         if self.topoType == "volume":
-
             f.write("Vol Number | f0 | f1 | f2 | f3 | f4 | f5 |f0dir|f1dir|f2dir|f3dir|f4dir|f5dir|\n")
             for i in range(self.nVol):
                 f.write(
@@ -727,7 +725,6 @@ class SurfaceTopology(Topology):
 
             for i in range(N):
                 for j in range(M):
-
                     _type, edge, node, index = indexPosition2D(i, j, N, M)
 
                     if _type == 0:  # Interior
@@ -1084,7 +1081,6 @@ class BlockTopology(Topology):
             _type, number, _, _ = indexPosition3D(i, j, k, N, M, L)
 
             if _type == 1:  # Face
-
                 if number in [0, 1]:
                     icount = i
                     imax = N
@@ -1122,7 +1118,6 @@ class BlockTopology(Topology):
                 gIndex[curIndex].append([ivol, i, j, k])
 
             elif _type == 2:  # Edge
-
                 if number in [0, 1, 4, 5]:
                     if self.edgeDir[ii][number] == -1:  # Its a reverse dir
                         curIndex = edgeIndex[self.edgeLink[ii][number]][N - i - 2]
@@ -1201,7 +1196,6 @@ class BlockTopology(Topology):
         self.lIndex = lIndex
 
         if greedyReorder:
-
             # Reorder the indices with a greedy scheme
             newIndices = np.zeros(len(gIndex), "intc")
             newIndices[:] = -1
@@ -1386,7 +1380,6 @@ class BlockTopology(Topology):
         self.lIndex = lIndex
 
         if greedyReorder:
-
             # Reorder the indices with a greedy scheme
             newIndices = np.zeros(len(gIndex), "intc")
             newIndices[:] = -1

--- a/tests/reg_tests/test_Blocks.py
+++ b/tests/reg_tests/test_Blocks.py
@@ -12,7 +12,6 @@ from pygeo import DVGeometry, geo_utils
 
 
 class RegTestPyGeo(unittest.TestCase):
-
     N_PROCS = 1
 
     def setUp(self):
@@ -286,7 +285,6 @@ the different test cases.
 
 
 def add_vars(geo, name, translate=False, rotate=None, scale=None, local=None, slocal=False):
-
     if translate:
         dvName = f"translate_{name}"
         geo.addGlobalDV(dvName=dvName, value=[0] * 3, func=f_translate)

--- a/tests/reg_tests/test_Cylinder.py
+++ b/tests/reg_tests/test_Cylinder.py
@@ -11,7 +11,6 @@ from pygeo import DVConstraints, DVGeometry, geo_utils
 
 
 class RegTestPyGeo(unittest.TestCase):
-
     N_PROCS = 1
 
     def setUp(self):

--- a/tests/reg_tests/test_DVConstraints.py
+++ b/tests/reg_tests/test_DVConstraints.py
@@ -133,7 +133,6 @@ test_params = [
 
 @parameterized_class(test_params)
 class RegTestPyGeo(unittest.TestCase):
-
     N_PROCS = 1
 
     def setUp(self):
@@ -907,7 +906,6 @@ class RegTestPyGeo(unittest.TestCase):
     def test_curvature(self, train=False, refDeriv=False):
         refFile = os.path.join(self.base_path, "ref/test_DVConstraints_curvature.ref")
         with BaseRegTest(refFile, train=train) as handler:
-
             # Use the RAE 2822 wing because we have a PLOT3D surface file for it
             DVGeo, DVCon = self.generate_dvgeo_dvcon("rae2822", addToDVGeo=True)
             surfFile = os.path.join(self.base_path, "../../input_files/deform_geometry_wing.xyz")
@@ -923,7 +921,6 @@ class RegTestPyGeo(unittest.TestCase):
     def test_curvature1D(self, train=False, refDeriv=False):
         refFile = os.path.join(self.base_path, "ref/test_DVConstraints_curvature1D.ref")
         with BaseRegTest(refFile, train=train) as handler:
-
             # Use the RAE 2822 wing because we have a PLOT3D surface file for it
             DVGeo, DVCon = self.generate_dvgeo_dvcon("c172", addToDVGeo=True)
 
@@ -963,7 +960,6 @@ class RegTestPyGeo(unittest.TestCase):
 
 @unittest.skipUnless(geogradInstalled, "requires geograd")
 class RegTestGeograd(unittest.TestCase):
-
     N_PROCS = 1
 
     def setUp(self):

--- a/tests/reg_tests/test_DVGeometry.py
+++ b/tests/reg_tests/test_DVGeometry.py
@@ -16,7 +16,6 @@ from pygeo import DVConstraints, DVGeometry
 
 
 class RegTestPyGeo(unittest.TestCase):
-
     N_PROCS = 1
 
     def setUp(self):

--- a/tests/reg_tests/test_DVGeometryCST.py
+++ b/tests/reg_tests/test_DVGeometryCST.py
@@ -47,7 +47,6 @@ DVs = [
 @unittest.skipUnless(prefoilImported, "preFoil is required for DVGeometryCST")
 @parameterized_class(airfoils)
 class DVGeometryCSTUnitTest(unittest.TestCase):
-
     N_PROCS = 1
 
     def setUp(self):

--- a/tests/reg_tests/test_DVGeometryESP.py
+++ b/tests/reg_tests/test_DVGeometryESP.py
@@ -39,7 +39,6 @@ test_params = [{"N_PROCS": 1, "name": "serial"}, {"N_PROCS": 4, "name": "paralle
 @unittest.skipUnless(mpiInstalled and ocsmInstalled, "MPI and pyOCSM are required.")
 @parameterized_class(test_params)
 class TestPyGeoESP_BasicCube(unittest.TestCase):
-
     # to be tested in serial and parallel automatically
     N_PROCS = 1
 
@@ -388,7 +387,6 @@ class TestPyGeoESP_BasicCube(unittest.TestCase):
 
 @unittest.skipUnless(mpiInstalled and ocsmInstalled, "MPI and pyOCSM are required.")
 class TestPyGeoESP_BasicCube_Distributed(unittest.TestCase):
-
     N_PROCS = 3
 
     def setUp(self):
@@ -587,7 +585,6 @@ class TestPyGeoESP_BasicCube_Distributed(unittest.TestCase):
 
 @unittest.skipUnless(mpiInstalled and ocsmInstalled, "MPI and pyOCSM are required.")
 class TestPyGeoESP_BasicCube_Distributed_OneProcBlank(unittest.TestCase):
-
     N_PROCS = 4
 
     def setUp(self):
@@ -750,7 +747,6 @@ class TestPyGeoESP_BasicCube_Distributed_OneProcBlank(unittest.TestCase):
 @unittest.skipUnless(mpiInstalled and ocsmInstalled, "MPI and pyOCSM are required.")
 @parameterized_class(test_params)
 class TestPyGeoESP_NACAFoil(unittest.TestCase):
-
     # serial and parallel handled automatically
     N_PROCS = 1
 

--- a/tests/reg_tests/test_DVGeometryMulti.py
+++ b/tests/reg_tests/test_DVGeometryMulti.py
@@ -29,11 +29,9 @@ inputDir = os.path.join(baseDir, "../../input_files")
 
 @unittest.skipUnless(pysurfInstalled, "requires pySurf")
 class TestDVGeoMulti(unittest.TestCase):
-
     N_PROCS = 1
 
     def test_boxes(self, train=False):
-
         # box1 and box2 intersect
         # box3 does not intersect anything
         comps = ["box1", "box2", "box3"]
@@ -145,7 +143,6 @@ class TestDVGeoMulti(unittest.TestCase):
 
         # Set up the complex and real DVGeoMulti objects
         for DVGeo in [DVGeo_complex, DVGeo_real]:
-
             # Add the intersection between box1 and box2
             DVGeo.addIntersection(
                 "box1",
@@ -225,12 +222,10 @@ class TestDVGeoMulti(unittest.TestCase):
         stepSize_CS = 1e-200
 
         for x in dvDict_real:
-
             nx = len(dvDict_real[x])
             funcSensFD[x] = np.zeros((nx, nNodes * 3))
             funcSensCS[x] = np.zeros((nx, nNodes * 3))
             for i in range(nx):
-
                 xRef_real = dvDict_real[x][i].copy()
                 xRef_complex = dvDict_complex[x][i].copy()
 

--- a/tests/reg_tests/test_DVGeometryVSP.py
+++ b/tests/reg_tests/test_DVGeometryVSP.py
@@ -32,7 +32,6 @@ test_params = [
 @unittest.skipUnless(openvspInstalled, "requires openvsp Python API")
 @parameterized_class(test_params)
 class RegTestPyGeoVSPParallel(unittest.TestCase):
-
     # this will be tested in serial and parallel automatically
     N_PROCS = 1
 
@@ -158,7 +157,6 @@ class RegTestPyGeoVSPParallel(unittest.TestCase):
 
 @unittest.skipUnless(openvspInstalled, "requires openvsp Python API")
 class RegTestPyGeoVSPSerial(unittest.TestCase):
-
     # this will be tested in serial only
     N_PROCS = 1
 

--- a/tests/reg_tests/test_ffdGeneration.py
+++ b/tests/reg_tests/test_ffdGeneration.py
@@ -14,11 +14,9 @@ baseDir = os.path.dirname(os.path.abspath(__file__))
 
 
 class TestFFDGeneration(unittest.TestCase):
-
     N_PROCS = 1
 
     def test_box_ffd(self, train=False, refDeriv=False):
-
         # Write duplicate of outerBoxFFD
         axes = ["i", "k", "j"]
         slices = np.array(
@@ -48,7 +46,6 @@ class TestFFDGeneration(unittest.TestCase):
         os.remove(copyName)
 
     def test_c172_fitted(self):
-
         # Scale all dimensions from millimeters to meters so that the tolerances match a regular use case
         leList = np.array([[0.0, 0.0, 0.1], [10.0, 0.0, 2500.0], [160.0, 0.0, 5280.0]]) * 1e-3
         teList = np.array([[1600.0, 0.0, 0.1], [1650.0, 0.0, 2500.0], [1320.0, 0.0, 5280.0]]) * 1e-3

--- a/tests/reg_tests/warning_childFFD.py
+++ b/tests/reg_tests/warning_childFFD.py
@@ -10,7 +10,6 @@ from pygeo import DVGeometry, geo_utils
 
 
 class RegTestPyGeo(unittest.TestCase):
-
     N_PROCS = 1
 
     def make_cube_ffd(self, file_name, x0, y0, z0, dx, dy, dz):


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
In very specific cases in GitHub Action builds for OpenAeroStruct, the matplotlib import was failing because of something in the font manager. With a brief effort, I was not able to reproduce it locally. One case that fails on GitHub Actions is with Python 3.8 (seems to be fixed in Python 3.10 and beyond) and the following Python package versions:

```
Package             Version   Editable project location                       Location                                                           Installer
------------------- --------- ----------------------------------------------- ------------------------------------------------------------------ ---------
attrs               22.2.0                                                    /opt/hostedtoolcache/Python/3.[8](https://github.com/mdolab/OpenAeroStruct/actions/runs/4175394644/jobs/7230248894#step:11:9).16/x64/lib/python3.8/site-packages pip
certifi             2022.12.7                                                 /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
charm               0.1.0                                                     /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages
charset-normalizer  3.0.1                                                     /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
contourpy           1.0.7                                                     /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
coverage            4.5.4                                                     /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
cycler              0.11.0                                                    /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
degen-geom          0.0.1                                                     /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages
exceptiongroup      1.1.0                                                     /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
fonttools           4.38.0                                                    /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
fortranformat       1.2.2                                                     /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages
idna                3.4                                                       /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
importlib-resources 5.10.2                                                    /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
iniconfig           2.0.0                                                     /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
kiwisolver          1.4.4                                                     /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
matplotlib          3.7.0                                                     /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
mdolab-baseclasses  1.7.0                                                     /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
mpi4py              3.1.4                                                     /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
networkx            3.0                                                       /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
numpy               1.20.0                                                    /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
numpy-stl           3.0.0                                                     /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
openaerostruct      2.5.3     /home/runner/work/OpenAeroStruct/OpenAeroStruct /home/runner/work/OpenAeroStruct/OpenAeroStruct
openmdao            3.10.0                                                    /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
openvsp             3.27.1                                                    /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages
packaging           23.0                                                      /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
pandas              1.5.3                                                     /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
parameterized       0.8.1                                                     /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
Pillow              [9](https://github.com/mdolab/OpenAeroStruct/actions/runs/4175394644/jobs/7230248894#step:11:10).4.0                                                     /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
pip                 23.0                                                      /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
pluggy              1.0.0                                                     /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
pyDOE2              1.3.0                                                     /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
pygeo               1.12.2                                                    /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
pyparsing           3.0.9                                                     /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
pyspline            1.5.2     /home/runner/work/OpenAeroStruct/pyspline       /home/runner/work/OpenAeroStruct/pyspline
pytest              7.2.1                                                     /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
pytest-cov          4.0.0                                                     /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
python-dateutil     2.8.2                                                     /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
python-utils        3.5.2                                                     /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
pytz                2022.7.1                                                  /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
requests            2.28.2                                                    /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
scipy               1.6.0                                                     /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
setuptools          56.0.0                                                    /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
six                 1.16.0                                                    /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
testflo             1.4.[10](https://github.com/mdolab/OpenAeroStruct/actions/runs/4175394644/jobs/7230248894#step:11:11)                                                    /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
tomli               2.0.1                                                     /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
urllib3             1.26.14                                                   /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
utilities           0.1.0                                                     /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages
wheel               0.38.4                                                    /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages pip
zipp                3.[13](https://github.com/mdolab/OpenAeroStruct/actions/runs/4175394644/jobs/7230248894#step:11:14).0                                                    /opt/hostedtoolcache/Python/3.8.[16](https://github.com/mdolab/OpenAeroStruct/actions/runs/4175394644/jobs/7230248894#step:11:17)/x64/lib/python3.8/site-packages pip
```

The error raised when pytest is then called is:

```
-> Run python -m pytest --cov-config=.coveragerc --cov=openaerostruct --cov-report=xml
Fatal Python error: Aborted

Thread 0x00007f22c67ff640 (most recent call first):
  File "/opt/hostedtoolcache/Python/3.[8](https://github.com/mdolab/OpenAeroStruct/actions/runs/4175394644/jobs/7230248894#step:12:9).16/x64/lib/python3.8/threading.py", line 306 in wait
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/threading.py", line 558 in wait
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/threading.py", line 1252 in run
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/threading.py", line [9](https://github.com/mdolab/OpenAeroStruct/actions/runs/4175394644/jobs/7230248894#step:12:10)32 in _bootstrap_inner
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/threading.py", line 890 in _bootstrap

Current thread 0x00007f22f61acb80 (most recent call first):
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/subprocess.py", line 1639 in _execute_child
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/subprocess.py", line 858 in __init__
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/subprocess.py", line 493 in run
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/subprocess.py", line 415 in check_output
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/matplotlib/font_manager.py", line 249 in _get_fontconfig_fonts
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/matplotlib/font_manager.py", line 275 in findSystemFonts
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/matplotlib/font_manager.py", line [10](https://github.com/mdolab/OpenAeroStruct/actions/runs/4175394644/jobs/7230248894#step:12:11)14 in __init__
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/matplotlib/font_manager.py", line 1542 in _load_fontmanager
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/matplotlib/font_manager.py", line 1548 in <module>
  File "<frozen importlib._bootstrap>", line 219 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 843 in exec_module
  File "<frozen importlib._bootstrap>", line 671 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 975 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 991 in _find_and_load
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/matplotlib/text.py", line 16 in <module>
  File "<frozen importlib._bootstrap>", line 219 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 843 in exec_module
  File "<frozen importlib._bootstrap>", line 671 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 975 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 991 in _find_and_load
  File "<frozen importlib._bootstrap>", line 219 in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1042 in _handle_fromlist
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/matplotlib/backend_bases.py", line 45 in <module>
  File "<frozen importlib._bootstrap>", line 219 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 843 in exec_module
  File "<frozen importlib._bootstrap>", line 671 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 975 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 991 in _find_and_load
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/matplotlib/contour.py", line 13 in <module>
  File "<frozen importlib._bootstrap>", line 219 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 843 in exec_module
  File "<frozen importlib._bootstrap>", line 671 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 975 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 991 in _find_and_load
  File "<frozen importlib._bootstrap>", line 219 in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1042 in _handle_fromlist
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/matplotlib/colorbar.py", line 19 in <module>
  File "<frozen importlib._bootstrap>", line 219 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 843 in exec_module
  File "<frozen importlib._bootstrap>", line 671 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 975 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 991 in _find_and_load
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/matplotlib/pyplot.py", line 52 in <module>
  File "<frozen importlib._bootstrap>", line 219 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 843 in exec_module
  File "<frozen importlib._bootstrap>", line 671 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 975 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 991 in _find_and_load
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/pygeo/parameterization/DVGeoCST.py", line 25 in <module>
  File "<frozen importlib._bootstrap>", line 219 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 843 in exec_module
  File "<frozen importlib._bootstrap>", line 671 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 975 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 991 in _find_and_load
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/pygeo/parameterization/__init__.py", line 3 in <module>
  File "<frozen importlib._bootstrap>", line 219 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 843 in exec_module
  File "<frozen importlib._bootstrap>", line 671 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 975 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 991 in _find_and_load
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/pygeo/__init__.py", line 7 in <module>
  File "<frozen importlib._bootstrap>", line 219 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 843 in exec_module
  File "<frozen importlib._bootstrap>", line 671 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 975 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 991 in _find_and_load
  File "/home/runner/work/OpenAeroStruct/OpenAeroStruct/openaerostruct/tests/test_aero_ffd.py", line 7 in <module>
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/_pytest/assertion/rewrite.py", line 168 in exec_module
  File "<frozen importlib._bootstrap>", line 671 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 975 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 991 in _find_and_load
  File "<frozen importlib._bootstrap>", line 1014 in _gcd_import
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/importlib/__init__.py", line 127 in import_module
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/_pytest/pathlib.py", line 533 in import_path
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/_pytest/python.py", line 618 in _importtestmodule
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/_pytest/python.py", line 529 in _getobj
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/_pytest/python.py", line 3[11](https://github.com/mdolab/OpenAeroStruct/actions/runs/4175394644/jobs/7230248894#step:12:12) in obj
  File "/opt/hostedtoolcache/Python/3.8.[16](https://github.com/mdolab/OpenAeroStruct/actions/runs/4175394644/jobs/7230248894#step:12:17)/x64/lib/python3.8/site-packages/_pytest/python.py", line 546 in _inject_setup_module_fixture
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/_pytest/python.py", line 532 in collect
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/_pytest/runner.py", line 370 in <lambda>
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/_pytest/runner.py", line 339 in from_call
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/_pytest/runner.py", line 370 in pytest_make_collect_report
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/pluggy/_callers.py", line 39 in _multicall
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/pluggy/_hooks.py", line 265 in __call__
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/_pytest/runner.py", line 538 in collect_one_node
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/_pytest/main.py", line 831 in genitems
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/_pytest/main.py", line 834 in genitems
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/_pytest/main.py", line 664 in perform_collect
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/_pytest/main.py", line 334 in pytest_collection
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/pluggy/_callers.py", line 39 in _multicall
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/pluggy/_hooks.py", line 265 in __call__
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/_pytest/main.py", line 323 in _main
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/_pytest/main.py", line 270 in wrap_session
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/_pytest/main.py", line 3[17](https://github.com/mdolab/OpenAeroStruct/actions/runs/4175394644/jobs/7230248894#step:12:18) in pytest_cmdline_main
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/pluggy/_callers.py", line 39 in _multicall
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/pluggy/_hooks.py", line [26](https://github.com/mdolab/OpenAeroStruct/actions/runs/4175394644/jobs/7230248894#step:12:27)5 in __call__
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/_pytest/config/__init__.py", line 167 in main
  ...
/home/runner/work/_temp/060ee01b-4c4b-47bf-b6e4-cd0064001b2b.sh: line 1: 117[27](https://github.com/mdolab/OpenAeroStruct/actions/runs/4175394644/jobs/7230248894#step:12:28) Aborted                 (core dumped) python -m pytest --cov-config=.coveragerc --cov=openaerostruct --cov-report=xml
```

By catching the ImportError instead of only if matplotlib is not installed, this problem is caught. The error may have something to do with https://github.com/matplotlib/matplotlib/issues/19560.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)