### PR TITLE
Fix scipy factorized import

### DIFF
--- a/pygeo/pyBlock.py
+++ b/pygeo/pyBlock.py
@@ -292,7 +292,7 @@ class pyBlock:
         NN = sparse.csr_matrix((vals, colInd, rowPtr))
         NNT = NN.T
         NTN = NNT * NN
-        solve = linalg.dsolve.factorized(NTN)
+        solve = linalg.factorized(NTN)
         self.coef = np.zeros((nCtl, 3))
         for idim in range(3):
             self.coef[:, idim] = solve(NNT * pts[:, idim])

--- a/pygeo/pyGeo.py
+++ b/pygeo/pyGeo.py
@@ -8,7 +8,7 @@ import numpy as np
 from pyspline import Curve, Surface
 from pyspline.utils import closeTecplot, openTecplot, writeTecplot2D
 from scipy import sparse
-from scipy.sparse.linalg.dsolve import factorized
+from scipy.sparse.linalg import factorized
 
 # Local modules
 from . import geo_utils


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->

SciPy has started producing the following deprecation warnings when running pyGeo:

```shell
DeprecationWarning: Please use `factorized` from the `scipy.sparse.linalg` namespace, the `scipy.sparse.linalg.eigen` namespace is deprecated.
```

This PR updates where we get the factorized function from to fix this. I checked, and the factorized function is available in the new location in [scipy 1.5.4](https://docs.scipy.org/doc/scipy-1.5.4/reference/generated/scipy.sparse.linalg.factorized.html#scipy.sparse.linalg.factorized) which is the oldest version we currently we support.

Exactly the same as https://github.com/mdolab/pyspline/pull/53

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
1 day

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
