### PR TITLE
Address flake8 rst docstring issues

### DIFF
--- a/pygeo/constraints/DVCon.py
+++ b/pygeo/constraints/DVCon.py
@@ -3139,6 +3139,8 @@ class DVConstraints:
         self, key, slope=1.0, name=None, start=0, stop=-1, config=None, childIdx=None, comp=None, DVGeoName="default"
     ):
         """
+        Add monotonic constraints to a give design variable.
+
         Parameters
         ----------
         key : str

--- a/pygeo/constraints/DVCon.py
+++ b/pygeo/constraints/DVCon.py
@@ -3139,7 +3139,7 @@ class DVConstraints:
         self, key, slope=1.0, name=None, start=0, stop=-1, config=None, childIdx=None, comp=None, DVGeoName="default"
     ):
         """
-        Add monotonic constraints to a give design variable.
+        Add monotonic constraints to a given design variable.
 
         Parameters
         ----------

--- a/pygeo/parameterization/BaseDVGeo.py
+++ b/pygeo/parameterization/BaseDVGeo.py
@@ -215,10 +215,12 @@ class BaseDVGeometry(ABC):
     def mapXDictToComp(self, inDict):
         """
         The inverse of :func:`mapXDictToDVGeo`, where we map the DVs to the composite space
+
         Parameters
         ----------
         inDict : dict
             The DVs to be mapped
+
         Returns
         -------
         dict
@@ -234,10 +236,12 @@ class BaseDVGeometry(ABC):
     def mapVecToDVGeo(self, inVec):
         """
         This is the vector version of :func:`mapXDictToDVGeo`, where the actual mapping is done
+
         Parameters
         ----------
         inVec : ndarray
             The DVs in a single 1D array
+
         Returns
         -------
         ndarray
@@ -250,10 +254,12 @@ class BaseDVGeometry(ABC):
     def mapVecToComp(self, inVec):
         """
         This is the vector version of :func:`mapXDictToComp`, where the actual mapping is done
+
         Parameters
         ----------
         inVec : ndarray
             The DVs in a single 1D array
+
         Returns
         -------
         ndarray
@@ -266,10 +272,12 @@ class BaseDVGeometry(ABC):
     def mapSensToComp(self, inVec):
         """
         Maps the sensitivity matrix to the composite design space
+
         Parameters
         ----------
         inVec : ndarray
             The sensitivities to be mapped
+
         Returns
         -------
         ndarray

--- a/pygeo/parameterization/DVGeoCST.py
+++ b/pygeo/parameterization/DVGeoCST.py
@@ -286,7 +286,7 @@ class DVGeometryCST(BaseDVGeometry):
         boundTol : float, optional
             Small absolute deviation by which the airfoil coordinates can exceed the initial
             minimum and maximum x coordinates, by default 1e-10.
-        kwargs
+        \*\*kwargs
             Any other parameters are ignored.
         """
         # Convert points to the type specified at initialization (with isComplex) and store the points
@@ -556,7 +556,7 @@ class DVGeometryCST(BaseDVGeometry):
             If you have many to do, it is faster to do many at once.
         ptSetName : str
             The name of set of points we are dealing with
-        kwargs
+        \*\*kwargs
             Any other parameters ignored, but this is maintained to allow the same
             interface as other DVGeo implementations.
 
@@ -691,7 +691,7 @@ class DVGeometryCST(BaseDVGeometry):
               values are the derivative seeds of the corresponding design variable.
         ptSetName : str
             The name of set of points we are dealing with
-        kwargs
+        \*\*kwargs
             Any other parameters ignored, but this is maintained to allow the same
             interface as other DVGeo implementations.
 
@@ -799,7 +799,7 @@ class DVGeometryCST(BaseDVGeometry):
         ptSetName : str
             Name of point-set to return. This must match ones of the
             given in an :func:`addPointSet()` call.
-        kwargs
+        \*\*kwargs
             Any other parameters ignored, but this is maintained to allow the same
             interface as other DVGeo implementations.
 
@@ -1207,7 +1207,7 @@ class DVGeometryCST(BaseDVGeometry):
             Number of coordinates to compute on each surface.
         ax : matplotlib Axes, optional
             Axes on which to plot airfoil.
-        **kwargs
+        \*\*kwargs
             Keyword arguments passed to matplotlib.pyplot.plot
 
         Returns

--- a/pygeo/parameterization/DVGeoSketch.py
+++ b/pygeo/parameterization/DVGeoSketch.py
@@ -83,6 +83,7 @@ class DVGeoSketch(BaseDVGeometry):
         """
         Add composite DVs. Note that this is essentially a preprocessing call which only works in serial
         at the moment.
+
         Parameters
         ----------
         dvName : str
@@ -168,11 +169,13 @@ class DVGeoSketch(BaseDVGeometry):
         convertSensitivityToDict(); it transforms the dictionary back
         into an array. This function is important for the matrix-free
         interface.
+
         Parameters
         ----------
         dIdxDict : dictionary
            Dictionary of information keyed by this object's
            design variables
+
         Returns
         -------
         dIdx : array
@@ -193,6 +196,7 @@ class DVGeoSketch(BaseDVGeometry):
         """
         This function takes the result of totalSensitivity and
         converts it to a dict for use in pyOptSparse
+
         Parameters
         ----------
         dIdx : array
@@ -205,6 +209,7 @@ class DVGeoSketch(BaseDVGeometry):
             Whether the sensitivity dIdx is with respect to the composite DVs or the original DVGeo DVs.
             If False, the returned dictionary will have keys corresponding to the original set of geometric DVs.
             If True,  the returned dictionary will have replace those with a single key corresponding to the composite DV name.
+
         Returns
         -------
         dIdxDict : dictionary


### PR DESCRIPTION
## Purpose
This PR fixes flake8 RST warnings when `flake8-rst-docstrings` extension enabled.

## Expected time until merged
Once docs build pass

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
