### PR TITLE
Fixing Constraints for new OM Parallelism Convention

### DIFF
--- a/pygeo/mphys/mphys_dvgeo.py
+++ b/pygeo/mphys/mphys_dvgeo.py
@@ -71,10 +71,8 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
         # compute the DVCon constraint values
         constraintfunc = dict()
         self.DVCon.evalFunctions(constraintfunc, includeLinear=True)
-        comm = self.comm
-        if comm.rank == 0:
-            for constraintname in constraintfunc:
-                outputs[constraintname] = constraintfunc[constraintname]
+        for constraintname in constraintfunc:
+            outputs[constraintname] = constraintfunc[constraintname]
 
         # we ran a compute so the inputs changed. update the dvcon jac
         # next time the jacvec product routine is called
@@ -212,66 +210,38 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
 
     def nom_addThicknessConstraints2D(self, name, leList, teList, nSpan=10, nChord=10):
         self.DVCon.addThicknessConstraints2D(leList, teList, nSpan, nChord, lower=1.0, name=name)
-        comm = self.comm
-        if comm.rank == 0:
-            self.add_output(name, distributed=True, val=np.ones((nSpan * nChord,)), shape=nSpan * nChord)
-        else:
-            self.add_output(name, distributed=True, shape=(0,))
+        self.add_output(name, distributed=False, val=np.ones((nSpan * nChord,)), shape=nSpan * nChord)
 
     def nom_addThicknessConstraints1D(self, name, ptList, nCon, axis):
         self.DVCon.addThicknessConstraints1D(ptList, nCon, axis, name=name)
-        comm = self.comm
-        if comm.rank == 0:
-            self.add_output(name, distributed=True, val=np.ones(nCon), shape=nCon)
-        else:
-            self.add_output(name, distributed=True, shape=(0))
+        self.add_output(name, distributed=False, val=np.ones(nCon), shape=nCon)
 
     def nom_addVolumeConstraint(self, name, leList, teList, nSpan=10, nChord=10):
         self.DVCon.addVolumeConstraint(leList, teList, nSpan=nSpan, nChord=nChord, name=name)
-        comm = self.comm
-        if comm.rank == 0:
-            self.add_output(name, distributed=True, val=1.0)
-        else:
-            self.add_output(name, distributed=True, shape=0)
+        self.add_output(name, distributed=False, val=1.0)
 
     def nom_add_LETEConstraint(self, name, volID, faceID, topID=None, childIdx=None):
         self.DVCon.addLeTeConstraints(volID, faceID, name=name, topID=topID, childIdx=childIdx)
         # how many are there?
         conobj = self.DVCon.linearCon[name]
         nCon = len(conobj.indSetA)
-        comm = self.comm
-        if comm.rank == 0:
-            self.add_output(name, distributed=True, val=np.zeros((nCon,)), shape=nCon)
-        else:
-            self.add_output(name, distributed=True, shape=0)
+        self.add_output(name, distributed=False, val=np.zeros((nCon,)), shape=nCon)
         return nCon
 
     def nom_addLERadiusConstraints(self, name, leList, nSpan, axis, chordDir):
         self.DVCon.addLERadiusConstraints(leList=leList, nSpan=nSpan, axis=axis, chordDir=chordDir, name=name)
-        comm = self.comm
-        if comm.rank == 0:
-            self.add_output(name, distributed=True, val=np.ones(nSpan), shape=nSpan)
-        else:
-            self.add_output(name, distributed=True, shape=0)
+        self.add_output(name, distributed=False, val=np.ones(nSpan), shape=nSpan)
 
     def nom_addCurvatureConstraint1D(self, name, start, end, nPts, axis, **kwargs):
         self.DVCon.addCurvatureConstraint1D(start=start, end=end, nPts=nPts, axis=axis, name=name, **kwargs)
-        comm = self.comm
-        if comm.rank == 0:
-            self.add_output(name, distributed=True, val=1.0)
-        else:
-            self.add_output(name, distributed=True, shape=0)
+        self.add_output(name, distributed=False, val=1.0)
 
     def nom_addLinearConstraintsShape(self, name, indSetA, indSetB, factorA, factorB, childIdx=None):
         self.DVCon.addLinearConstraintsShape(
             indSetA=indSetA, indSetB=indSetB, factorA=factorA, factorB=factorB, name=name, childIdx=childIdx
         )
         lSize = len(indSetA)
-        comm = self.comm
-        if comm.rank == 0:
-            self.add_output(name, distributed=True, val=np.zeros(lSize), shape=lSize)
-        else:
-            self.add_output(name, distributed=True, shape=0)
+        self.add_output(name, distributed=False, val=np.zeros(lSize), shape=lSize)
 
     def nom_addRefAxis(self, childIdx=None, **kwargs):
         # references axes are only needed in FFD-based DVGeo objects
@@ -308,14 +278,9 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
                 for dvname in self.constraintfuncsens[constraintname]:
                     if dvname in d_inputs:
                         dcdx = self.constraintfuncsens[constraintname][dvname]
-                        if self.comm.rank == 0:
-                            dout = d_outputs[constraintname]
-                            jvtmp = np.dot(np.transpose(dcdx), dout)
-                        else:
-                            jvtmp = 0.0
+                        dout = d_outputs[constraintname]
+                        jvtmp = np.dot(np.transpose(dcdx), dout)
                         d_inputs[dvname] += jvtmp
-                        # OM does the reduction itself
-                        # d_inputs[dvname] += self.comm.reduce(jvtmp, op=MPI.SUM, root=0)
 
             for ptSetName in self.DVGeo.ptSetNames:
                 if ptSetName in self.omPtSetList:


### PR DESCRIPTION
## Purpose
The new OM serial derivative parallelism convention made how we handled constraints invalid as we had different derivative values on different procs for serial inputs. The solution for this is to make constraints serial and consistent on each proc. I changed all the constraints in the MPhys wrapper as well as the `compute()` and `compute_jacvec_product()` functions to reflect these changes.

## Expected time until merged
1 week.

## Type of change

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [X] Maintenance update
- [ ] Other (please describe)

## Testing
I tested this using the DAFoam MPhys aero-only and aerostructural tests. The derivatives are correct (even for TACS structural functionals) and OpenMDAO does not complain about derivative inconsistencies.

## Checklist

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
