### PR TITLE
Add triangulated surface constraint to MPhys wrapper

### DIFF
--- a/pygeo/constraints/DVCon.py
+++ b/pygeo/constraints/DVCon.py
@@ -1359,6 +1359,7 @@ class DVConstraints:
 
     def addTriangulatedSurfaceConstraint(
         self,
+        comm,
         surface_1_name=None,
         DVGeo_1_name="default",
         surface_2_name="default",
@@ -1464,6 +1465,7 @@ class DVConstraints:
 
         # Finally add constraint object
         self.constraints[typeName][conName] = TriangulatedSurfaceConstraint(
+            comm,
             conName,
             surface_1,
             surface_1_name,

--- a/pygeo/constraints/areaConstraint.py
+++ b/pygeo/constraints/areaConstraint.py
@@ -258,7 +258,7 @@ class TriangulatedSurfaceConstraint(GeometricConstraint):
         if self.perim_length > self.max_perim:
             failflag = True
             if self.comm.rank == 0:
-                print("Intersection length ", str(perim_length), " exceeds tol, returning fail flag")
+                print(f"Intersection length {self.perim_length} exceeds tol {self.max_perim}, returning fail flag")
         else:
             failflag = False
         return KS, perim_length, failflag

--- a/pygeo/constraints/areaConstraint.py
+++ b/pygeo/constraints/areaConstraint.py
@@ -22,6 +22,7 @@ class TriangulatedSurfaceConstraint(GeometricConstraint):
 
     def __init__(
         self,
+        comm,
         name,
         surface_1,
         surface_1_name,
@@ -40,6 +41,8 @@ class TriangulatedSurfaceConstraint(GeometricConstraint):
             raise ImportError("Geograd package must be installed to use triangulated surface constraint")
 
         super().__init__(name, 2, -1e10, 0.0, scale, None, addToPyOpt)
+
+        self.comm = comm
 
         # get the point sets
         self.surface_1_name = surface_1_name
@@ -233,7 +236,7 @@ class TriangulatedSurfaceConstraint(GeometricConstraint):
             mindist_tmp,
             self.rho,
             self.maxdim,
-            MPI.COMM_WORLD.py2f(),
+            self.comm.py2f(),
         )
         # second run gets the well-conditioned KS
         KS, perim_length, mindist, _, _ = geograd_parallel.compute(
@@ -246,7 +249,7 @@ class TriangulatedSurfaceConstraint(GeometricConstraint):
             mindist,
             self.rho,
             self.maxdim,
-            MPI.COMM_WORLD.py2f(),
+            self.comm.py2f(),
         )
 
         self.perim_length = perim_length
@@ -254,7 +257,7 @@ class TriangulatedSurfaceConstraint(GeometricConstraint):
 
         if self.perim_length > self.max_perim:
             failflag = True
-            if MPI.COMM_WORLD.rank == 0:
+            if self.comm.rank == 0:
                 print("Intersection length ", str(perim_length), " exceeds tol, returning fail flag")
         else:
             failflag = False
@@ -275,7 +278,7 @@ class TriangulatedSurfaceConstraint(GeometricConstraint):
             self.minimum_distance,
             self.rho,
             self.maxdim,
-            MPI.COMM_WORLD.py2f(),
+            self.comm.py2f(),
         )
         return deriv_output
 

--- a/pygeo/mphys/mphys_dvgeo.py
+++ b/pygeo/mphys/mphys_dvgeo.py
@@ -218,16 +218,16 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
         else:
             self.add_output(name, distributed=True, shape=(0,))
 
-    def nom_addThicknessConstraints1D(self, name, ptList, nCon, axis):
-        self.DVCon.addThicknessConstraints1D(ptList, nCon, axis, name=name)
+    def nom_addThicknessConstraints1D(self, name, ptList, nCon, axis, scaled=True):
+        self.DVCon.addThicknessConstraints1D(ptList, nCon, axis, name=name, scaled=scaled)
         comm = self.comm
         if comm.rank == 0:
             self.add_output(name, distributed=True, val=np.ones(nCon), shape=nCon)
         else:
             self.add_output(name, distributed=True, shape=(0))
 
-    def nom_addVolumeConstraint(self, name, leList, teList, nSpan=10, nChord=10):
-        self.DVCon.addVolumeConstraint(leList, teList, nSpan=nSpan, nChord=nChord, name=name)
+    def nom_addVolumeConstraint(self, name, leList, teList, nSpan=10, nChord=10, surfaceName="default"):
+        self.DVCon.addVolumeConstraint(leList, teList, nSpan=nSpan, nChord=nChord, name=name, surfaceName=surfaceName)
         comm = self.comm
         if comm.rank == 0:
             self.add_output(name, distributed=True, val=1.0)
@@ -273,36 +273,36 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
         else:
             self.add_output(name, distributed=True, shape=0)
 
-    def nom_addTriangulatedSurfaceConstraint(   
+    def nom_addTriangulatedSurfaceConstraint(
         self,
-            name,
-            surface_1_name=None,
-            DVGeo_1_name="default",
-            surface_2_name="default",
-            DVGeo_2_name="default",
-            rho=50.0,
-            heuristic_dist=None,
-            max_perim=3.0,
-        ):
-            self.DVCon.addTriangulatedSurfaceConstraint(
-                comm=self.comm,
-                surface_1_name=surface_1_name,
-                DVGeo_1_name=DVGeo_1_name,
-                surface_2_name=surface_2_name,
-                DVGeo_2_name=DVGeo_2_name,
-                rho=rho,
-                heuristic_dist=heuristic_dist,
-                max_perim=max_perim,
-                name=name,
-            )
+        name,
+        surface_1_name=None,
+        DVGeo_1_name="default",
+        surface_2_name="default",
+        DVGeo_2_name="default",
+        rho=50.0,
+        heuristic_dist=None,
+        max_perim=3.0,
+    ):
+        self.DVCon.addTriangulatedSurfaceConstraint(
+            comm=self.comm,
+            surface_1_name=surface_1_name,
+            DVGeo_1_name=DVGeo_1_name,
+            surface_2_name=surface_2_name,
+            DVGeo_2_name=DVGeo_2_name,
+            rho=rho,
+            heuristic_dist=heuristic_dist,
+            max_perim=max_perim,
+            name=name,
+        )
 
-            comm = self.comm
-            if comm.rank == 0:
-                self.add_output(f"{name}_KS", distributed=True, val=0, shape=1)
-                self.add_output(f"{name}_perim", distributed=True, val=0, shape=1)
-            else:
-                self.add_output(f"{name}_KS", distributed=True, shape=0)
-                self.add_output(f"{name}_perim", distributed=True, shape=0)
+        comm = self.comm
+        if comm.rank == 0:
+            self.add_output(f"{name}_KS", distributed=True, val=0, shape=1)
+            self.add_output(f"{name}_perim", distributed=True, val=0, shape=1)
+        else:
+            self.add_output(f"{name}_KS", distributed=True, shape=0)
+            self.add_output(f"{name}_perim", distributed=True, shape=0)
 
     def nom_addRefAxis(self, childIdx=None, **kwargs):
         # references axes are only needed in FFD-based DVGeo objects

--- a/pygeo/mphys/mphys_dvgeo.py
+++ b/pygeo/mphys/mphys_dvgeo.py
@@ -2,6 +2,7 @@
 from mpi4py import MPI
 import numpy as np
 import openmdao.api as om
+from openmdao.api import AnalysisError
 
 # Local modules
 from .. import DVConstraints, DVGeometry, DVGeometryESP, DVGeometryVSP
@@ -72,8 +73,11 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
         constraintfunc = dict()
         self.DVCon.evalFunctions(constraintfunc, includeLinear=True)
         comm = self.comm
-        if comm.rank == 0:
-            for constraintname in constraintfunc:
+        for constraintname in constraintfunc:
+            if constraintname == "fail":
+                raise AnalysisError("Analysis error in geometric constraints")
+
+            if comm.rank == 0:
                 outputs[constraintname] = constraintfunc[constraintname]
 
         # we ran a compute so the inputs changed. update the dvcon jac

--- a/pygeo/mphys/mphys_dvgeo.py
+++ b/pygeo/mphys/mphys_dvgeo.py
@@ -73,7 +73,10 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
         constraintfunc = dict()
         self.DVCon.evalFunctions(constraintfunc, includeLinear=True)
         comm = self.comm
+
         for constraintname in constraintfunc:
+            # if any constraint returned a fail flag throw an error to OpenMDAO
+            # all constraints need the same fail flag, no <name_> prefix
             if constraintname == "fail":
                 raise AnalysisError("Analysis error in geometric constraints")
 
@@ -300,13 +303,8 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
             name=name,
         )
 
-        comm = self.comm
-        if comm.rank == 0:
-            self.add_output(f"{name}_KS", distributed=True, val=0, shape=1)
-            self.add_output(f"{name}_perim", distributed=True, val=0, shape=1)
-        else:
-            self.add_output(f"{name}_KS", distributed=True, shape=0)
-            self.add_output(f"{name}_perim", distributed=True, shape=0)
+        self.add_output(f"{name}_KS", distributed=False, val=0, shape=1)
+        self.add_output(f"{name}_perim", distributed=False, val=0, shape=1)
 
     def nom_addRefAxis(self, childIdx=None, **kwargs):
         # references axes are only needed in FFD-based DVGeo objects


### PR DESCRIPTION
## Purpose
This adds `TriangulatedSurfaceConstraint` to `mphys_dvgeo` so packaging constraints (GeoGrad) can be used in MPhys and cleans up a few things related to that constraint in DVCon. The GeoGrad fail flag, which skips CFD if the intersection between the two objects exceeds the tolerance, has also been exposed to the MPhys wrapper using OpenMDAO's`AnalysisError`. The parallelism fix in #191 was also done for this constraint.

## Expected time until merged
1 week

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
I have a runscript modified from an old MACH runscript that runs as expected with MPhys in place of MACH. If someone wants to use it in a docker container I can pass that and the input files along.

## Checklist
- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
