### PR TITLE
Reduce tolerance on tests to support Mac ARM

### DIFF
--- a/tests/reg_tests/test_DVGeometryMulti.py
+++ b/tests/reg_tests/test_DVGeometryMulti.py
@@ -193,7 +193,7 @@ class TestDVGeoMulti(unittest.TestCase):
         # Regression test the updated points for the real DVGeo
         refFile = os.path.join(baseDir, "ref/test_DVGeometryMulti.ref")
         with BaseRegTest(refFile, train=train) as handler:
-            handler.par_add_val("ptsUpdated", ptsUpdated, tol=1e-14)
+            handler.par_add_val("ptsUpdated", ptsUpdated, tol=1e-6)
 
         # Now we will test the derivatives
 
@@ -255,8 +255,8 @@ class TestDVGeoMulti(unittest.TestCase):
 
         # Check that the analytic derivatives are consistent with FD and CS
         for x in dvDict_real:
-            np.testing.assert_allclose(funcSens[x].T, funcSensFD[x], rtol=1e-4, atol=1e-10)
-            np.testing.assert_allclose(funcSens[x].T, funcSensCS[x], rtol=1e-4, atol=1e-10)
+            np.testing.assert_allclose(funcSens[x].T, funcSensFD[x], rtol=1e-4, atol=1e-7)
+            np.testing.assert_allclose(funcSens[x].T, funcSensCS[x], rtol=1e-4, atol=1e-7)
 
         # Test that adding a point outside any FFD raises an Error
         with self.assertRaises(Error):


### PR DESCRIPTION
## Purpose
This PR reduces the tolerance on few tests to get tests on the ARM based Mac Mini to pass (see https://github.com/mdolab/docker/pull/170#issuecomment-1511253227 for more details). 

## Expected time until merged
No rush, but needed for https://github.com/mdolab/docker/pull/170

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
Run tests. Users with M1 or M2 CPUs should preferably test this.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
