### PR TITLE
change extra flags test check to compiler

### DIFF
--- a/.github/test_real.sh
+++ b/.github/test_real.sh
@@ -2,8 +2,8 @@
 set -e
 ./input_files/get-input-files.sh
 
-# All tests should pass on Ubuntu
-if [[ $OS == "ubuntu" ]]; then
+# All tests should pass on GCC
+if [[ $COMPILERS == "gcc" ]]; then
     EXTRA_FLAGS='--disallow_skipped'
 fi
 

--- a/.github/test_real.sh
+++ b/.github/test_real.sh
@@ -2,8 +2,8 @@
 set -e
 ./input_files/get-input-files.sh
 
-# All tests should pass on GCC
-if [[ $COMPILERS == "gcc" ]]; then
+# No tests should be skipped on GCC and non Intel MPI
+if [[ $COMPILERS == "gcc" ]] && [[ -z $I_MPI_ROOT ]]; then
     EXTRA_FLAGS='--disallow_skipped'
 fi
 


### PR DESCRIPTION
## Purpose
New Intel Ubuntu docker images do not have ESP and OpenVSP installed, resulting in the tests failing, as no tests are allowed to skip (see https://github.com/mdolab/docker/pull/193). This PR updated the check to the compiler instead of the OS.

## Expected time until merged
Should be quick once tests pass.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
