### PR TITLE
Disallow skipped tests only on x86 

### DIFF
--- a/.github/test_real.sh
+++ b/.github/test_real.sh
@@ -2,8 +2,8 @@
 set -e
 ./input_files/get-input-files.sh
 
-# No tests should be skipped on GCC and non Intel MPI
-if [[ $COMPILERS == "gcc" ]] && [[ -z $I_MPI_ROOT ]]; then
+# No tests should be skipped on GCC, non Intel MPI, and x86 arch
+if [[ $COMPILERS == "gcc" ]] && [[ -z $I_MPI_ROOT ]] && [[ "$(arch)" == "x86_64" ]]; then
     EXTRA_FLAGS='--disallow_skipped'
 fi
 


### PR DESCRIPTION
## Purpose
ESP is at the moment not going to be installed on the ARM docker images, resulting in tests failing (see https://github.com/mdolab/docker/pull/170). This PR adds an architecture check on adding the `--disallow_skipped` flag. 

## Expected time until merged
No rush.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
