### PR TITLE
Fix **kwargs in docstrings

### DIFF
--- a/pygeo/parameterization/DVGeoCST.py
+++ b/pygeo/parameterization/DVGeoCST.py
@@ -286,7 +286,7 @@ class DVGeometryCST(BaseDVGeometry):
         boundTol : float, optional
             Small absolute deviation by which the airfoil coordinates can exceed the initial
             minimum and maximum x coordinates, by default 1e-10.
-        \*\*kwargs
+        **kwargs
             Any other parameters are ignored.
         """
         # Convert points to the type specified at initialization (with isComplex) and store the points
@@ -556,7 +556,7 @@ class DVGeometryCST(BaseDVGeometry):
             If you have many to do, it is faster to do many at once.
         ptSetName : str
             The name of set of points we are dealing with
-        \*\*kwargs
+        **kwargs
             Any other parameters ignored, but this is maintained to allow the same
             interface as other DVGeo implementations.
 
@@ -691,7 +691,7 @@ class DVGeometryCST(BaseDVGeometry):
               values are the derivative seeds of the corresponding design variable.
         ptSetName : str
             The name of set of points we are dealing with
-        \*\*kwargs
+        **kwargs
             Any other parameters ignored, but this is maintained to allow the same
             interface as other DVGeo implementations.
 
@@ -799,7 +799,7 @@ class DVGeometryCST(BaseDVGeometry):
         ptSetName : str
             Name of point-set to return. This must match ones of the
             given in an :func:`addPointSet()` call.
-        \*\*kwargs
+        **kwargs
             Any other parameters ignored, but this is maintained to allow the same
             interface as other DVGeo implementations.
 
@@ -1207,7 +1207,7 @@ class DVGeometryCST(BaseDVGeometry):
             Number of coordinates to compute on each surface.
         ax : matplotlib Axes, optional
             Axes on which to plot airfoil.
-        \*\*kwargs
+        **kwargs
             Keyword arguments passed to matplotlib.pyplot.plot
 
         Returns


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
Replaces `\*\*kwargs` in docstrings with `**kwargs` to avoid these deprecation warnings:
```
/home/ali/repos/pygeo/pygeo/parameterization/DVGeoCST.py:269: DeprecationWarning: invalid escape sequence '\*'
  """
  ```

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
0 seconds

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
