### PR TITLE
Moved OpenVSP version check to fix API docs

### DIFF
--- a/pygeo/parameterization/DVGeoVSP.py
+++ b/pygeo/parameterization/DVGeoVSP.py
@@ -30,22 +30,6 @@ except ImportError:
         vspInstalled = False
 
 
-vspOutOfDate = False
-if vspInstalled:
-    vspVersionStr = openvsp.GetVSPVersion()
-    words = vspVersionStr.split()
-    vspVersion = words[-1]
-    # VSP is installed, but version too old
-    if Version(vspVersion) < Version("3.28.0"):
-        vspOutOfDate = True
-    # Prior to OpenVSP 3.33.0, the "s" parameter varried between [0, 0.5]
-    elif Version(vspVersion) < Version("3.33.0"):
-        SMAX = 0.5
-    # After this version, the range was changed to [0, 1.0].
-    else:  # Version(vsp_version) >= Version("3.33.0")
-        SMAX = 1.0
-
-
 class DVGeometryVSP(DVGeoSketch):
     """
     A class for manipulating OpenVSP geometry.
@@ -90,6 +74,21 @@ class DVGeometryVSP(DVGeoSketch):
     """
 
     def __init__(self, fileName, comm=MPI.COMM_WORLD, scale=1.0, comps=[], projTol=0.01):
+        vspOutOfDate = False
+        if vspInstalled:
+            vspVersionStr = openvsp.GetVSPVersion()
+            words = vspVersionStr.split()
+            vspVersion = words[-1]
+            # VSP is installed, but version too old
+            if Version(vspVersion) < Version("3.28.0"):
+                vspOutOfDate = True
+            # Prior to OpenVSP 3.33.0, the "s" parameter varied between [0, 0.5]
+            elif Version(vspVersion) < Version("3.33.0"):
+                self.SMAX = 0.5
+            # After this version, the range was changed to [0, 1.0].
+            else:  # Version(vsp_version) >= Version("3.33.0")
+                self.SMAX = 1.0
+
         if not vspInstalled:
             raise ImportError(
                 "The OpenVSP Python API is required in order to use DVGeometryVSP. "
@@ -283,10 +282,10 @@ class DVGeometryVSP(DVGeoSketch):
             rg = ug
             if vg < 0.5:
                 # This point is on the lower surface
-                sg = SMAX * 2.0 * vg
+                sg = self.SMAX * 2.0 * vg
             else:
                 # This point is on the upper surface
-                sg = SMAX * 2.0 * (1.0 - vg)
+                sg = self.SMAX * 2.0 * (1.0 - vg)
             # tg = 0.5 places the initial guess in the middle of the upper and lower surfaces for the volume
             # Note: If the point we're looking for actually lies on the surface openvsp's
             # projection algorithm (FindRSTGuess) will still quickly locate it, since our volume interpolation


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
#198 broke the API docs for DVGeometryVSP, the modules that follow it in `__init__.py` (DVGeometryESP, DVGeometryMulti), and the MPhys wrapper. The problem is that the `openvsp.GetVSPVersion()` call occurs outside the class, which does not work when we have mock imports for the doc build. To fix this, I moved the version check into the `__init__` function.

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
1 week

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->
Check the API docs for the latest docs build and compare to the PR build. All the API docs should be working on the PR build.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
