### PR TITLE
Add JOSS paper citation info

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,94 @@
+cff-version: "1.2.0"
+authors:
+- family-names: Hajdik
+  given-names: Hannah M.
+  orcid: "https://orcid.org/0000-0002-5103-7159"
+- family-names: Yildirim
+  given-names: Anil
+  orcid: "https://orcid.org/0000-0002-1814-9191"
+- family-names: Wu
+  given-names: Neil
+  orcid: "https://orcid.org/0000-0001-8856-9661"
+- family-names: Brelje
+  given-names: Benjamin J.
+  orcid: "https://orcid.org/0000-0002-9819-3028"
+- family-names: Seraj
+  given-names: Sabet
+  orcid: "https://orcid.org/0000-0002-7364-0071"
+- family-names: Mangano
+  given-names: Marco
+  orcid: "https://orcid.org/0000-0001-8495-3578"
+- family-names: Anibal
+  given-names: Joshua L.
+  orcid: "https://orcid.org/0000-0002-7795-2523"
+- family-names: Jonsson
+  given-names: Eirikur
+  orcid: "https://orcid.org/0000-0002-5166-3889"
+- family-names: Adler
+  given-names: Eytan J.
+  orcid: "https://orcid.org/0000-0002-8716-1805"
+- family-names: Mader
+  given-names: Charles A.
+  orcid: "https://orcid.org/0000-0002-2744-1151"
+- family-names: Kenway
+  given-names: Gaetan K. W.
+  orcid: "https://orcid.org/0000-0003-1352-5458"
+- family-names: Martins
+  given-names: Joaquim R. R. A.
+  orcid: "https://orcid.org/0000-0003-2143-1478"
+doi: 10.5281/zenodo.8027706
+message: If you use this software, please cite our article in the
+  Journal of Open Source Software.
+preferred-citation:
+  authors:
+  - family-names: Hajdik
+    given-names: Hannah M.
+    orcid: "https://orcid.org/0000-0002-5103-7159"
+  - family-names: Yildirim
+    given-names: Anil
+    orcid: "https://orcid.org/0000-0002-1814-9191"
+  - family-names: Wu
+    given-names: Neil
+    orcid: "https://orcid.org/0000-0001-8856-9661"
+  - family-names: Brelje
+    given-names: Benjamin J.
+    orcid: "https://orcid.org/0000-0002-9819-3028"
+  - family-names: Seraj
+    given-names: Sabet
+    orcid: "https://orcid.org/0000-0002-7364-0071"
+  - family-names: Mangano
+    given-names: Marco
+    orcid: "https://orcid.org/0000-0001-8495-3578"
+  - family-names: Anibal
+    given-names: Joshua L.
+    orcid: "https://orcid.org/0000-0002-7795-2523"
+  - family-names: Jonsson
+    given-names: Eirikur
+    orcid: "https://orcid.org/0000-0002-5166-3889"
+  - family-names: Adler
+    given-names: Eytan J.
+    orcid: "https://orcid.org/0000-0002-8716-1805"
+  - family-names: Mader
+    given-names: Charles A.
+    orcid: "https://orcid.org/0000-0002-2744-1151"
+  - family-names: Kenway
+    given-names: Gaetan K. W.
+    orcid: "https://orcid.org/0000-0003-1352-5458"
+  - family-names: Martins
+    given-names: Joaquim R. R. A.
+    orcid: "https://orcid.org/0000-0003-2143-1478"
+  date-published: 2023-07-19
+  doi: 10.21105/joss.05319
+  issn: 2475-9066
+  issue: 87
+  journal: Journal of Open Source Software
+  publisher:
+    name: Open Journals
+  start: 5319
+  title: "pyGeo: A geometry package for multidisciplinary design
+    optimization"
+  type: article
+  url: "https://joss.theoj.org/papers/10.21105/joss.05319"
+  volume: 8
+title: "pyGeo: A geometry package for multidisciplinary design
+  optimization"

--- a/README.md
+++ b/README.md
@@ -2,38 +2,26 @@
 [![Build Status](https://dev.azure.com/mdolab/Public/_apis/build/status/mdolab.pygeo?branchName=main)](https://dev.azure.com/mdolab/Public/_build/latest?definitionId=17&branchName=main)
 [![Documentation Status](https://readthedocs.com/projects/mdolab-pygeo/badge/?version=latest)](https://mdolab-pygeo.readthedocs-hosted.com/en/latest/?badge=latest)
 [![codecov](https://codecov.io/gh/mdolab/pygeo/branch/main/graph/badge.svg?token=N2L58WGCDI)](https://codecov.io/gh/mdolab/pygeo)
+[![DOI](https://joss.theoj.org/papers/10.21105/joss.05319/status.svg)](https://doi.org/10.21105/joss.05319)
 
 pyGeo is an object oriented geometry manipulation framework for multidisciplinary design optimization (MDO).
-It can be used for MDO within the [MACH framework](https://github.com/mdolab/MACH-Aero) and within [OpenMDAO](https://github.com/OpenMDAO/OpenMDAO) through [Mphys](https://github.com/OpenMDAO/mphys).
+It can be used for MDO within the [MACH framework](https://github.com/mdolab/MACH-Aero) and within [OpenMDAO](https://github.com/OpenMDAO/OpenMDAO) through [MPhys](https://github.com/OpenMDAO/mphys).
 Its parameterization options include a free form deformation (FFD) implementation, an interface to NASA's [OpenVSP](https://openvsp.org/) parametric geometry tool, and an interface to the CAD package [ESP](https://acdl.mit.edu/ESP/).
 It also includes geometric constraints and utility functions for geometry manipulation.
 
 ![](doc/images/DPW4_FFD-27745.gif)
 
 ## Documentation
-
 Please see the [documentation](https://mdolab-pygeo.readthedocs-hosted.com/en/latest/) for installation details and API documentation.
 
 To locally build the documentation, enter the `doc` folder and enter `make html` in terminal.
 You can then view the built documentation in the `_build` folder.
 
+
 ## Citation
-
 Please cite pyGeo in any publication for which you find it useful.
-For more background, theory, and figures, see the [this paper](http://umich.edu/~mdolaboratory/pdf/Kenway2010b.pdf).
+Citation information can be found [here](https://mdolab-pygeo.readthedocs-hosted.com/en/latest/citation.html).
 
-G. K. W. Kenway, Kennedy, G. J., and Martins, J. R. R. A., “A CAD-Free Approach to High-Fidelity Aerostructural Optimization”, in Proceedings of the 13th AIAA/ISSMO Multidisciplinary Analysis Optimization Conference, Fort Worth, TX, 2010.
-```
-@conference {Kenway:2010:C,
-	title = {A {CAD}-Free Approach to High-Fidelity Aerostructural Optimization},
-	booktitle = {Proceedings of the 13th AIAA/ISSMO Multidisciplinary Analysis Optimization Conference},
-	year = {2010},
-	note = {AIAA 2010-9231},
-	month = {September},
-	address = {Fort Worth,~TX},
-	author = {Gaetan K. W. Kenway and Graeme J. Kennedy and Joaquim R. R. A. Martins}
-}
-```
 
 ## License
 pyGeo is licensed under the Apache License, Version 2.0 (the "License"). See `LICENSE` for the full license.

--- a/doc/citation.rst
+++ b/doc/citation.rst
@@ -1,0 +1,42 @@
+.. _citation:
+
+Citation
+========
+If you use pyGeo, please cite the following paper:
+
+    \H. Hajdik, A. Yildirim, N. Wu, B. Brelje, S. Seraj, M. Mangano, J. Anibal, E. Jonsson, E. Adler, C. A. Mader, G. Kenway, and J. R. R. A. Martins. pyGeo: A geometry package for multidisciplinary design optimization. Journal of Open Source Software,  8(87), 5319, July 2023. https://doi.org/10.21105/joss.05319
+
+The paper is available online from the Journal of Open Source Software `here <https://joss.theoj.org/papers/10.21105/joss.05319>`__.
+To cite this paper, you can use the following BibTeX entry:
+
+.. code-block:: bibtex
+
+    @article{Hajdik2023,
+        doi = {10.21105/joss.05319},
+        year = {2023},
+        publisher = {The Open Journal},
+        volume = {8},
+        number = {87},
+        pages = {5319},
+        author = {Hannah M. Hajdik and Anil Yildirim and Neil Wu and Benjamin J. Brelje and Sabet Seraj and Marco Mangano and Joshua L. Anibal and Eirikur Jonsson and Eytan J. Adler and Charles A. Mader and Gaetan K. W. Kenway and Joaquim R. R. A. Martins},
+        title = {pyGeo: A geometry package for multidisciplinary design optimization},
+        journal = {Journal of Open Source Software}
+    }
+
+
+For more background and theory on the legacy FFD implementation, see [this paper](http://umich.edu/~mdolaboratory/pdf/Kenway2010b.pdf).
+
+    \G. K. W. Kenway, Kennedy, G. J., and Martins, J. R. R. A., “A CAD-Free Approach to High-Fidelity Aerostructural Optimization”, in Proceedings of the 13th AIAA/ISSMO Multidisciplinary Analysis Optimization Conference, Fort Worth, TX, 2010.
+
+
+.. code-block:: bibtex
+
+    @conference {Kenway2010,
+        title = {A {CAD}-Free Approach to High-Fidelity Aerostructural Optimization},
+        booktitle = {Proceedings of the 13th AIAA/ISSMO Multidisciplinary Analysis Optimization Conference},
+        year = {2010},
+        note = {AIAA 2010-9231},
+        month = {September},
+        address = {Fort Worth,~TX},
+        author = {Gaetan K. W. Kenway and Graeme J. Kennedy and Joaquim R. R. A. Martins}
+    }

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,5 +17,6 @@ pyGeo is a geometry manipulation framework for multidisciplinary design optimiza
    introduction
    contribute
    install
+   citation
    tutorial
    API


### PR DESCRIPTION
## Purpose
- Add separate citation page in docs like the one in [pyOptSparse](https://mdolab-pyoptsparse.readthedocs-hosted.com/en/latest/citation.html)
- Update readme for docs link and  JOSS badge
- Add `citation.cff` which adds citation info to right bar of GitHub repo where the bibtex can be copied from

I don't know if the mention of the conference paper on the citation docs page should be phrased differently, let me know if you have other ideas.

## Expected time until merged
a day or two

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Docs test passes and everything looks okay

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
