### PR TITLE
DVGeoESP compatibality with ESP 122

### DIFF
--- a/pygeo/parameterization/DVGeoESP.py
+++ b/pygeo/parameterization/DVGeoESP.py
@@ -655,7 +655,7 @@ class DVGeometryESP(DVGeoSketch):
             modelCopy = self.espModel.Copy()
             n_branches, _, _ = modelCopy.Info()
             modelCopy.NewBrch(
-                n_branches, modelCopy.GetCode("dump"), "<none>", 0, filename, "0", "0", "", "", "", "", "", ""
+                n_branches, modelCopy.GetCode("dump"), "<none>", 0, filename, "0", "0", "0", "", "", "", "", ""
             )
             modelCopy.Build(0, 0)
 


### PR DESCRIPTION
## Purpose
The docker images are being [updated from ESP 120 to 122](https://github.com/mdolab/docker/pull/231), which is required by TACS for the TACS-CAPS interface. Some of the ESP tests failed due to a minor UI change in ESP's python wrapper. The GCC images on that PR will keep failing until this is merged.

## Expected time until merged
Depends on which PR we want to merge first

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [X] Maintenance update
- [ ] Other (please describe)

## Testing
I have a local docker image with new ESP and this branch and the pyGeo tests pass. I'm not sure if this will pass with the old ESP

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
