### PR TITLE
Adding sliding curves for DVGeoMulti

### DIFF
--- a/pygeo/parameterization/DVGeoMulti.py
+++ b/pygeo/parameterization/DVGeoMulti.py
@@ -184,7 +184,7 @@ class DVGeometryMulti:
         project=False,
         marchDir=1,
         includeCurves=False,
-        slidingCurves=[],
+        slidingCurves=None,
         intDir=None,
         curveEpsDict=None,
         trackSurfaces=None,
@@ -275,6 +275,8 @@ class DVGeometryMulti:
         # Assign mutable defaults
         if featureCurves is None:
             featureCurves = []
+        if slidingCurves is None:
+            slidingCurves = []
         if curveEpsDict is None:
             curveEpsDict = {}
         if trackSurfaces is None:

--- a/tests/reg_tests/test_DVGeometryMulti.py
+++ b/tests/reg_tests/test_DVGeometryMulti.py
@@ -460,9 +460,10 @@ class TestDVGeoMulti(unittest.TestCase):
         # Reshape into a nPtsGlobal, 3 array
         ptsUpdated = globalPoints.reshape((nPtsGlobal, 3))
 
-        # Test that the X and Z coordinates are unchanged
+        # Test that the X and Z coordinates are unchanged and Y coordinates are changed
         for i in range(np.size(pts, 0)):
             self.assertAlmostEqual(pts[i, 0], ptsUpdated[i, 0])
+            self.assertNotEqual(pts[i, 1], ptsUpdated[i, 1])
             self.assertAlmostEqual(pts[i, 2], ptsUpdated[i, 2])
 
 

--- a/tests/reg_tests/test_DVGeometryMulti.py
+++ b/tests/reg_tests/test_DVGeometryMulti.py
@@ -442,8 +442,8 @@ class TestDVGeoMulti(unittest.TestCase):
         ptsUpdated = globalPoints.reshape((nPtsGlobal, 3))
 
         # Test that the X and Z coordinates are unchanged and Y coordinates are changed
-        np.testing.assert_allclose(pts[:, 0], ptsUpdated[:, 0], rtol=1e-4, atol=1e-10)
-        np.testing.assert_allclose(pts[:, 2], ptsUpdated[:, 2], rtol=1e-4, atol=1e-10)
+        np.testing.assert_allclose(pts[:, 0], ptsUpdated[:, 0], rtol=1e-10, atol=1e-10)
+        np.testing.assert_allclose(pts[:, 2], ptsUpdated[:, 2], rtol=1e-10, atol=1e-10)
 
         with self.assertRaises(AssertionError):
             np.testing.assert_allclose(pts[:, 1], ptsUpdated[:, 1], rtol=1e-4, atol=1e-10)

--- a/tests/reg_tests/test_DVGeometryMulti.py
+++ b/tests/reg_tests/test_DVGeometryMulti.py
@@ -442,10 +442,11 @@ class TestDVGeoMulti(unittest.TestCase):
         ptsUpdated = globalPoints.reshape((nPtsGlobal, 3))
 
         # Test that the X and Z coordinates are unchanged and Y coordinates are changed
-        for i in range(np.size(pts, 0)):
-            np.testing.assert_almost_equal(pts[i, 0], ptsUpdated[i, 0])
-            np.testing.assert_equal(pts[i, 1] == ptsUpdated[i, 1], False)
-            np.testing.assert_almost_equal(pts[i, 2], ptsUpdated[i, 2])
+        np.testing.assert_allclose(pts[:, 0], ptsUpdated[:, 0], rtol=1e-4, atol=1e-10)
+        np.testing.assert_allclose(pts[:, 2], ptsUpdated[:, 2], rtol=1e-4, atol=1e-10)
+
+        with self.assertRaises(AssertionError):
+            np.testing.assert_allclose(pts[:, 1], ptsUpdated[:, 1], rtol=1e-4, atol=1e-10)
 
 
 @unittest.skipUnless(pysurfInstalled, "requires pySurf")


### PR DESCRIPTION
## Purpose

There are cases when using the intersection method in which a curve on a surface should be preserved to make sure that the patch does not change size or the curve is maintained to a certain shape. For example, maintaining the interface line between a propeller hub and nacelle is important to ensure a realistic boundary condition on each patch. This PR adds this sort of tracking.

These changes are actually made by @anilyil.

## Expected time until merged
2 weeks.

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
I have run this locally and also checked the derivatives to make sure the code is correct.

## Checklist

- [X] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
