### PR TITLE
Fixed LE radius projection

### DIFF
--- a/pygeo/constraints/DVCon.py
+++ b/pygeo/constraints/DVCon.py
@@ -928,14 +928,13 @@ class DVConstraints:
         chordDir /= np.linalg.norm(chordDir)
         for i in range(nSpan):
             # Project actual node:
-            up, down, fail = geo_utils.projectNode(X[i], chordDir, p0, p1 - p0, p2 - p0)
+            lePts[i], fail = geo_utils.projectNodePosOnly(X[i], chordDir, p0, p1 - p0, p2 - p0)
             if fail > 0:
                 raise Error(
                     "There was an error projecting a node "
-                    "at (%f, %f, %f) with normal (%f, %f, %f)."
+                    "at (%f, %f, %f) in direction (%f, %f, %f)."
                     % (X[i, 0], X[i, 1], X[i, 2], chordDir[0], chordDir[1], chordDir[2])
                 )
-            lePts[i] = up
 
         # Check that points can form radius
         d = np.linalg.norm(coords[:, 0, :] - coords[:, 1, :], axis=1)


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
The projection to the leading edge for the LE radius constraint currently projects points to the LE and TE even though only the LE point is used. @bernardopacini found that the TE projection can sometimes fail. Following @anilyil's suggestion, I changed the projection to only project to the LE.

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
1 week

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->
The existing LE radius constraint tests pass.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
