### PR TITLE
Add dvs as real to optimization problem

### DIFF
--- a/pygeo/parameterization/DVGeo.py
+++ b/pygeo/parameterization/DVGeo.py
@@ -1774,9 +1774,9 @@ class DVGeometry(BaseDVGeometry):
         def _checkArrLength(key, nIn, nRef):
             if nIn != nRef:
                 raise Error(
-                        f"Incorrect number of design variables for DV: {key}.\n"
-                        + f"Expecting {nRef} variables but received {nIn}"
-                    )
+                    f"Incorrect number of design variables for DV: {key}.\n"
+                    + f"Expecting {nRef} variables but received {nIn}"
+                )
 
         for key in dvDict:
             if key in self.DV_listGlobal:
@@ -2929,7 +2929,9 @@ class DVGeometry(BaseDVGeometry):
         # then we simply return without adding any of the other DVs
         if self.useComposite:
             dv = self.DVComposite
-            optProb.addVarGroup(dv.name, dv.nVal, "c", value=dv.value.real, lower=dv.lower, upper=dv.upper, scale=dv.scale)
+            optProb.addVarGroup(
+                dv.name, dv.nVal, "c", value=dv.value.real, lower=dv.lower, upper=dv.upper, scale=dv.scale
+            )
 
             # add the linear DV constraints that replace the existing bounds!
             # Note that we assume all DVs are added here, i.e. no ignoreVars or any of the vars = False
@@ -2974,11 +2976,23 @@ class DVGeometry(BaseDVGeometry):
                         dv = varLists[lst][key]
                         if key not in freezeVars:
                             optProb.addVarGroup(
-                                dv.name, dv.nVal, "c", value=dv.value.real, lower=dv.lower, upper=dv.upper, scale=dv.scale
+                                dv.name,
+                                dv.nVal,
+                                "c",
+                                value=dv.value.real,
+                                lower=dv.lower,
+                                upper=dv.upper,
+                                scale=dv.scale,
                             )
                         else:
                             optProb.addVarGroup(
-                                dv.name, dv.nVal, "c", value=dv.value.real, lower=dv.value, upper=dv.value, scale=dv.scale
+                                dv.name,
+                                dv.nVal,
+                                "c",
+                                value=dv.value.real,
+                                lower=dv.value,
+                                upper=dv.value,
+                                scale=dv.scale,
                             )
 
         # Add variables from the children

--- a/pygeo/parameterization/DVGeo.py
+++ b/pygeo/parameterization/DVGeo.py
@@ -1771,42 +1771,32 @@ class DVGeometry(BaseDVGeometry):
         if self.useComposite:
             dvDict = self.mapXDictToDVGeo(dvDict)
 
+        def _checkArrLength(key, nIn, nRef):
+            if nIn != nRef:
+                raise Error(
+                        f"Incorrect number of design variables for DV: {key}.\n"
+                        + f"Expecting {nRef} variables but received {nIn}"
+                    )
+
         for key in dvDict:
             if key in self.DV_listGlobal:
                 vals_to_set = np.atleast_1d(dvDict[key]).astype("D")
-                if len(vals_to_set) != self.DV_listGlobal[key].nVal:
-                    raise Error(
-                        f"Incorrect number of design variables for DV: {key}.\n"
-                        + f"Expecting {self.DV_listGlobal[key].nVal} variables but received {len(vals_to_set)}"
-                    )
-
+                _checkArrLength(key, len(vals_to_set), self.DV_listGlobal[key].nVal)
                 self.DV_listGlobal[key].value = vals_to_set
 
             if key in self.DV_listLocal:
                 vals_to_set = np.atleast_1d(dvDict[key]).astype("D")
-                if len(vals_to_set) != self.DV_listLocal[key].nVal:
-                    raise Error(
-                        f"Incorrect number of design variables for DV: {key}.\n"
-                        + f"Expecting {self.DV_listLocal[key].nVal} variables but received {len(vals_to_set)}"
-                    )
+                _checkArrLength(key, len(vals_to_set), self.DV_listLocal[key].nVal)
                 self.DV_listLocal[key].value = vals_to_set
 
             if key in self.DV_listSectionLocal:
                 vals_to_set = np.atleast_1d(dvDict[key]).astype("D")
-                if len(vals_to_set) != self.DV_listSectionLocal[key].nVal:
-                    raise Error(
-                        f"Incorrect number of design variables for DV: {key}.\n"
-                        + f"Expecting {self.DV_listSectionLocal[key].nVal} variables but received {len(vals_to_set)}"
-                    )
+                _checkArrLength(key, len(vals_to_set), self.DV_listSectionLocal[key].nVal)
                 self.DV_listSectionLocal[key].value = vals_to_set
 
             if key in self.DV_listSpanwiseLocal:
                 vals_to_set = np.atleast_1d(dvDict[key]).astype("D")
-                if len(vals_to_set) != self.DV_listSpanwiseLocal[key].nVal:
-                    raise Error(
-                        f"Incorrect number of design variables for DV: {key}.\n"
-                        + f"Expecting {self.DV_listSpanwiseLocal[key].nVal} variables but received {len(vals_to_set)}"
-                    )
+                _checkArrLength(key, len(vals_to_set), self.DV_listSpanwiseLocal[key].nVal)
                 self.DV_listSpanwiseLocal[key].value = vals_to_set
 
             # Jacobians are, in general, no longer up to date

--- a/pygeo/parameterization/DVGeo.py
+++ b/pygeo/parameterization/DVGeo.py
@@ -2939,7 +2939,7 @@ class DVGeometry(BaseDVGeometry):
         # then we simply return without adding any of the other DVs
         if self.useComposite:
             dv = self.DVComposite
-            optProb.addVarGroup(dv.name, dv.nVal, "c", value=dv.value, lower=dv.lower, upper=dv.upper, scale=dv.scale)
+            optProb.addVarGroup(dv.name, dv.nVal, "c", value=dv.value.real, lower=dv.lower, upper=dv.upper, scale=dv.scale)
 
             # add the linear DV constraints that replace the existing bounds!
             # Note that we assume all DVs are added here, i.e. no ignoreVars or any of the vars = False
@@ -2984,11 +2984,11 @@ class DVGeometry(BaseDVGeometry):
                         dv = varLists[lst][key]
                         if key not in freezeVars:
                             optProb.addVarGroup(
-                                dv.name, dv.nVal, "c", value=dv.value, lower=dv.lower, upper=dv.upper, scale=dv.scale
+                                dv.name, dv.nVal, "c", value=dv.value.real, lower=dv.lower, upper=dv.upper, scale=dv.scale
                             )
                         else:
                             optProb.addVarGroup(
-                                dv.name, dv.nVal, "c", value=dv.value, lower=dv.value, upper=dv.value, scale=dv.scale
+                                dv.name, dv.nVal, "c", value=dv.value.real, lower=dv.value, upper=dv.value, scale=dv.scale
                             )
 
         # Add variables from the children


### PR DESCRIPTION
## Purpose
DVs should be real before adding to pyOptSparse, otherwise implicit casting might fail and hang the optimization process, as happens with SLSQP described in https://github.com/mdolab/MACH-Aero/issues/96. This was initially caused by a change in pyOptSparse (see [this PR and comment](https://github.com/mdolab/pyoptsparse/pull/348#discussion_r1210642210)). 

This PR addresses this issue. Additionally, made a small refactor to reduce multiple raise Error calls. 

Ideally, DVGeo DVs should not be allocated by default as complex, but cast as needed. This is however a more fundamental change. This PR is intended to get SLSQP working again quickly, as it has been broken for months, and allow SLSQP [MACH-Aero integration tests](https://github.com/mdolab/MACH-Aero/pull/98) to be added. 

## Expected time until merged
ASAP as MACH-Aero and SLSQP do not work past pyOptSparse 2.10 

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Run MACH-Aero tests

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
