### PR TITLE
Fix bug breaking multiple DVGeos for MPhys

### DIFF
--- a/pygeo/__init__.py
+++ b/pygeo/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.13.0"
+__version__ = "1.13.1"
 
 from .pyNetwork import pyNetwork
 from .pyGeo import pyGeo

--- a/pygeo/mphys/mphys_dvgeo.py
+++ b/pygeo/mphys/mphys_dvgeo.py
@@ -560,7 +560,18 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
         )
         self.add_output(name, distributed=False, val=np.ones(nCon), shape=nCon)
 
-    def nom_addVolumeConstraint(self, name, leList, teList, nSpan=10, nChord=10, scaled=True, surfaceName="default"):
+    def nom_addVolumeConstraint(
+        self,
+        name,
+        leList,
+        teList,
+        nSpan=10,
+        nChord=10,
+        scaled=True,
+        surfaceName="default",
+        DVGeoName="default",
+        compNames=None,
+    ):
         """
         Add a DVCon volume constraint to the problem
         Wrapper for :meth:`addVolumeConstraint <.DVConstraints.addVolumeConstraint>`
@@ -582,14 +593,55 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
             See wrapped
         surfaceName : str, optional
             See wrapped
+        DVGeoName : str, optional
+            See wrapped
+        compNames : list, optional
+            See wrapped
         """
 
         self.DVCon.addVolumeConstraint(
-            leList, teList, nSpan=nSpan, nChord=nChord, scaled=scaled, name=name, surfaceName=surfaceName
+            leList,
+            teList,
+            nSpan=nSpan,
+            nChord=nChord,
+            scaled=scaled,
+            name=name,
+            surfaceName=surfaceName,
+            DVGeoName=DVGeoName,
+            compNames=compNames,
         )
         self.add_output(name, distributed=False, val=1.0)
 
-    def nom_addProjectedAreaConstraint(self, name, axis, scaled=True, surface_name="default"):
+    def nom_addSurfaceAreaConstraint(
+        self, name, scaled=True, surfaceName="default", DVGeoName="default", compNames=None
+    ):
+        """
+        Add a DVCon surface area constraint to the problem
+        Wrapper for :meth:`addSurfaceAreaConstraint <.DVConstraints.addSurfaceAreaConstraint>`
+        Input parameters are identical to those in wrapped function unless otherwise specified
+
+        Parameters
+        ----------
+        name :
+            See wrapped
+        scaled : bool, optional
+            See wrapped
+        surfaceName : str, optional
+            See wrapped
+        DVGeoName : str, optional
+            See wrapped
+        compNames : list, optional
+            See wrapped
+        """
+
+        self.DVCon.addSurfaceAreaConstraint(
+            name=name, scaled=scaled, surfaceName=surfaceName, DVGeoName=DVGeoName, compNames=compNames
+        )
+        self.add_output(name, distributed=False, val=1.0)
+
+    def nom_addProjectedAreaConstraint(
+        self, name, axis, scaled=True, surface_name="default", DVGeoName="default", compNames=None
+    ):
         """
         Add a DVCon projected area constraint to the problem
         Wrapper for :meth:`addProjectedAreaConstraint <.DVConstraints.addProjectedAreaConstraint>`
@@ -605,9 +657,15 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
             See wrapped
         surface_name : str, optional
             See wrapped
+        DVGeoName : str, optional
+            See wrapped
+        compNames : list, optional
+            See wrapped
         """
 
-        self.DVCon.addProjectedAreaConstraint(axis, name=name, scaled=scaled, surfaceName=surface_name)
+        self.DVCon.addProjectedAreaConstraint(
+            axis, name=name, scaled=scaled, surfaceName=surface_name, DVGeoName=DVGeoName, compNames=compNames
+        )
         self.add_output(name, distributed=False, val=1.0)
 
     def nom_add_LETEConstraint(self, name, volID, faceID, topID=None, childName=None):

--- a/pygeo/mphys/mphys_dvgeo.py
+++ b/pygeo/mphys/mphys_dvgeo.py
@@ -277,12 +277,6 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
         if not isComposite:
             self.add_input(dvName, distributed=False, shape=len(np.atleast_1d(value)))
 
-        # call the dvgeo object and add this dv
-        if childName is None:
-            DVGeo.addGlobalDV(dvName, value, func)
-        else:
-            DVGeo.children[childName].addGlobalDV(dvName, value, func)
-
     def nom_addLocalDV(self, dvName, axis="y", pointSelect=None, childName=None, isComposite=False, DVGeoName=None):
         # if we have multiple DVGeos use the one specified by name
         DVGeo = self.nom_getDVGeo(DVGeoName=DVGeoName)

--- a/pygeo/mphys/mphys_dvgeo.py
+++ b/pygeo/mphys/mphys_dvgeo.py
@@ -679,9 +679,9 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
         self.DVCon.addCurvatureConstraint1D(start=start, end=end, nPts=nPts, axis=axis, name=name, **kwargs)
         self.add_output(name, distributed=False, val=1.0)
 
-    def nom_addLinearConstraintsShape(self, name, indSetA, indSetB, factorA, factorB, childName=None):
+    def nom_addLinearConstraintsShape(self, name, indSetA, indSetB, factorA, factorB, childName=None, DVGeoName="default"):
         self.DVCon.addLinearConstraintsShape(
-            indSetA=indSetA, indSetB=indSetB, factorA=factorA, factorB=factorB, name=name, childName=childName
+            indSetA=indSetA, indSetB=indSetB, factorA=factorA, factorB=factorB, name=name, childName=childName, DVGeoName=DVGeoName
         )
         lSize = len(indSetA)
         self.add_output(name, distributed=False, val=np.zeros(lSize), shape=lSize)

--- a/pygeo/mphys/mphys_dvgeo.py
+++ b/pygeo/mphys/mphys_dvgeo.py
@@ -228,7 +228,7 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
     Wrapper for DVGeo functions
     """
 
-    def nom_addGlobalDV(self, dvName, value, func, childName=None, isComposite=False, DVGeoName=None):
+    def nom_addGlobalDV(self, dvName, value, func, childName=None, isComposite=False, DVGeoName=None, prependName=False):
         """
         Add a global design variable to the DVGeo object. This is a wrapper for the DVGeo.addGlobalDV method.
 
@@ -265,6 +265,11 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
         if not isinstance(DVGeo, DVGeometry):
             raise RuntimeError(f"Only FFD-based DVGeo objects can use global DVs, not type: {type(DVGeo).__name__}")
 
+        # if this DVGeo object has a name attribute, prepend it to match up with what DVGeo is expecting
+        # this keeps track of DVs between multiple DVGeo objects
+        if DVGeoName is not None and prependName:
+            dvName = DVGeoName + "_" + dvName
+
         # call the dvgeo object and add this dv
         DVGeo.addGlobalDV(dvName, value, func)
 
@@ -274,13 +279,18 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
         if not isComposite:
             self.add_input(dvName, distributed=False, shape=len(np.atleast_1d(value)))
 
-    def nom_addLocalDV(self, dvName, axis="y", pointSelect=None, childName=None, isComposite=False, DVGeoName=None):
+    def nom_addLocalDV(self, dvName, axis="y", pointSelect=None, childName=None, isComposite=False, DVGeoName=None, prependName=False):
         # if we have multiple DVGeos use the one specified by name
         DVGeo = self.nom_getDVGeo(childName=childName, DVGeoName=DVGeoName)
 
         # local DVs are only added to FFD-based DVGeo objects
         if not isinstance(DVGeo, DVGeometry):
             raise RuntimeError(f"Only FFD-based DVGeo objects can use local DVs, not type: {type(DVGeo).__name__}")
+
+        # if this DVGeo object has a name attribute, prepend it to match up with what DVGeo is expecting
+        # this keeps track of DVs between multiple DVGeo objects
+        if DVGeoName is not None and prependName:
+            dvName = DVGeoName + "_" + dvName
 
         # add the DV to DVGeo
         nVal = DVGeo.addLocalDV(dvName, axis=axis, pointSelect=pointSelect)
@@ -304,6 +314,7 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
         orient2="svd",
         config=None,
         DVGeoName=None,
+        prependName=False,
     ):
         """
         Add one or more section local design variables to the DVGeometry object
@@ -362,6 +373,11 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
                 f"Only FFD-based DVGeo objects can use local section DVs, not type: {type(DVGeo).__name__}"
             )
 
+        # if this DVGeo object has a name attribute, prepend it to match up with what DVGeo is expecting
+        # this keeps track of DVs between multiple DVGeo objects
+        if DVGeoName is not None and prependName:
+            dvName = DVGeoName + "_" + dvName
+
         # add the DV to DVGeo
         nVal = DVGeo.addLocalSectionDV(dvName, secIndex, axis, pointSelect, volList, orient0, orient2, config)
 
@@ -369,7 +385,7 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
         self.add_input(dvName, distributed=False, shape=nVal)
         return nVal
 
-    def nom_addShapeFunctionDV(self, dvName, shapes, childName=None, config=None, DVGeoName=None):
+    def nom_addShapeFunctionDV(self, dvName, shapes, childName=None, config=None, DVGeoName=None, prependName=False):
         """
         Add one or more local shape function design variables to the DVGeometry object
         Wrapper for :meth:`addShapeFunctionDV <.DVGeometry.addShapeFunctionDV>`
@@ -412,6 +428,11 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
                 f"Only FFD-based DVGeo objects can use shape function DVs, not type: {type(DVGeo).__name__}"
             )
 
+        # if this DVGeo object has a name attribute, prepend it to match up with what DVGeo is expecting
+        # this keeps track of DVs between multiple DVGeo objects
+        if DVGeoName is not None and prependName:
+            dvName = DVGeoName + "_" + dvName
+
         # add the DV to DVGeo
         nVal = DVGeo.addShapeFunctionDV(dvName, shapes, config)
 
@@ -419,9 +440,14 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
         self.add_input(dvName, distributed=False, shape=nVal)
         return nVal
 
-    def nom_addGeoCompositeDV(self, dvName, ptSetName=None, u=None, scale=None, DVGeoName=None, **kwargs):
+    def nom_addGeoCompositeDV(self, dvName, ptSetName=None, u=None, scale=None, DVGeoName=None, prependName=False, **kwargs):
         # if we have multiple DVGeos use the one specified by name
         DVGeo = self.nom_getDVGeo(DVGeoName=DVGeoName)
+
+        # if this DVGeo object has a name attribute, prepend it to match up with what DVGeo is expecting
+        # this keeps track of DVs between multiple DVGeo objects
+        if DVGeoName is not None and prependName:
+            dvName = DVGeoName + "_" + dvName
 
         # call the dvgeo object and add this dv
         DVGeo.addCompositeDV(dvName, ptSetName=ptSetName, u=u, scale=scale, **kwargs)

--- a/pygeo/mphys/mphys_dvgeo.py
+++ b/pygeo/mphys/mphys_dvgeo.py
@@ -259,17 +259,14 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
         """
 
         # if we have multiple DVGeos use the one specified by name
-        DVGeo = self.nom_getDVGeo(DVGeoName=DVGeoName)
+        DVGeo = self.nom_getDVGeo(childName=childName, DVGeoName=DVGeoName)
 
         # global DVs are only added to FFD-based DVGeo objects
         if not isinstance(DVGeo, DVGeometry):
             raise RuntimeError(f"Only FFD-based DVGeo objects can use global DVs, not type: {type(DVGeo).__name__}")
 
         # call the dvgeo object and add this dv
-        if childName is None:
-            DVGeo.addGlobalDV(dvName, value, func)
-        else:
-            DVGeo.children[childName].addGlobalDV(dvName, value, func)
+        DVGeo.addGlobalDV(dvName, value, func)
 
         # define the input
         # When composite DVs are used, input is not required for the default DVs. Now the composite DVs are
@@ -279,16 +276,14 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
 
     def nom_addLocalDV(self, dvName, axis="y", pointSelect=None, childName=None, isComposite=False, DVGeoName=None):
         # if we have multiple DVGeos use the one specified by name
-        DVGeo = self.nom_getDVGeo(DVGeoName=DVGeoName)
+        DVGeo = self.nom_getDVGeo(childName=childName, DVGeoName=DVGeoName)
 
         # local DVs are only added to FFD-based DVGeo objects
         if not isinstance(DVGeo, DVGeometry):
             raise RuntimeError(f"Only FFD-based DVGeo objects can use local DVs, not type: {type(DVGeo).__name__}")
 
-        if childName is None:
-            nVal = DVGeo.addLocalDV(dvName, axis=axis, pointSelect=pointSelect)
-        else:
-            nVal = DVGeo.children[childName].addLocalDV(dvName, axis=axis, pointSelect=pointSelect)
+        # add the DV to DVGeo
+        nVal = DVGeo.addLocalDV(dvName, axis=axis, pointSelect=pointSelect)
 
         # define the input
         # When composite DVs are used, input is not required for the default DVs. Now the composite DVs are
@@ -359,7 +354,7 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
         """
 
         # if we have multiple DVGeos use the one specified by name
-        DVGeo = self.nom_getDVGeo(DVGeoName=DVGeoName)
+        DVGeo = self.nom_getDVGeo(childName=childName, DVGeoName=DVGeoName)
 
         # local DVs are only added to FFD-based DVGeo objects
         if not isinstance(DVGeo, DVGeometry):
@@ -367,21 +362,8 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
                 f"Only FFD-based DVGeo objects can use local section DVs, not type: {type(DVGeo).__name__}"
             )
 
-        # add the DV to a normal DVGeo
-        if childName is None:
-            nVal = DVGeo.addLocalSectionDV(dvName, secIndex, axis, pointSelect, volList, orient0, orient2, config)
-        # add the DV to a child DVGeo
-        else:
-            nVal = DVGeo.children[childName].addLocalSectionDV(
-                dvName,
-                secIndex,
-                axis,
-                pointSelect,
-                volList,
-                orient0,
-                orient2,
-                config,
-            )
+        # add the DV to DVGeo
+        nVal = DVGeo.addLocalSectionDV(dvName, secIndex, axis, pointSelect, volList, orient0, orient2, config)
 
         # define the input
         self.add_input(dvName, distributed=False, shape=nVal)
@@ -422,7 +404,7 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
         """
 
         # if we have multiple DVGeos use the one specified by name
-        DVGeo = self.nom_getDVGeo(DVGeoName=DVGeoName)
+        DVGeo = self.nom_getDVGeo(childName=childName, DVGeoName=DVGeoName)
 
         # shape function DVs are only added to FFD-based DVGeo objects
         if not isinstance(DVGeo, DVGeometry):
@@ -430,12 +412,8 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
                 f"Only FFD-based DVGeo objects can use shape function DVs, not type: {type(DVGeo).__name__}"
             )
 
-        # add the DV to a normal DVGeo
-        if childName is None:
-            nVal = DVGeo.addShapeFunctionDV(dvName, shapes, config)
-        # add the DV to a child DVGeo
-        else:
-            nVal = DVGeo.children[childName].addShapeFunctionDV(dvName, shapes, config)
+        # add the DV to DVGeo
+        nVal = DVGeo.addShapeFunctionDV(dvName, shapes, config)
 
         # define the input
         self.add_input(dvName, distributed=False, shape=nVal)
@@ -497,18 +475,15 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
 
     def nom_addRefAxis(self, childName=None, DVGeoName=None, **kwargs):
         # if we have multiple DVGeos use the one specified by name
-        DVGeo = self.nom_getDVGeo(DVGeoName=DVGeoName)
+        DVGeo = self.nom_getDVGeo(childName=childName, DVGeoName=DVGeoName)
 
         # references axes are only needed in FFD-based DVGeo objects
         if not isinstance(DVGeo, DVGeometry):
             raise RuntimeError(f"Only FFD-based DVGeo objects can use reference axes, not type: {type(DVGeo).__name__}")
 
         # add ref axis to this DVGeo
-        if childName is None:
-            return DVGeo.addRefAxis(**kwargs)
+        return DVGeo.addRefAxis(**kwargs)
         # add ref axis to the specified child
-        else:
-            return DVGeo.children[childName].addRefAxis(**kwargs)
 
     """
     Wrapper for DVCon functions


### PR DESCRIPTION
## Purpose
A small change introduced to DVGeo with how DV names were handled wasn't propagated to the MPhys wrapper. This change was to append the DVGeo name to the DV name when a name is present, which mostly only happens when you have multiple DVGeos to keep track of. MPhys wasn't expecting this full name so it wasn't accumulating the derivatives and they were all 0. Try this one cool trick to get 0-1s in one iteration!

I also cleaned up some random duplicate code and simplified the handling of child DVGeos in MPhys

## Expected time until merged
This isn't urgent, likely no one else has this use case

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Creating two DVGeo objects (or just naming one) leads to immediate 0-1s. Maybe someone with MPhys scripts (especially using child DVGeos) should run using this to make sure I didn't miss anything?

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works **
- [ ] I have added necessary documentation

** is it time to talk about how we can implement tests for our MPhys wrappers