### PR TITLE
Fix spanwise Local DV offset

### DIFF
--- a/pygeo/parameterization/DVGeo.py
+++ b/pygeo/parameterization/DVGeo.py
@@ -2976,11 +2976,23 @@ class DVGeometry(BaseDVGeometry):
                         dv = varLists[lst][key]
                         if key not in freezeVars:
                             optProb.addVarGroup(
-                                dv.name, dv.nVal, "c", value=np.real(dv.value), lower=dv.lower, upper=dv.upper, scale=dv.scale
+                                dv.name,
+                                dv.nVal,
+                                "c",
+                                value=dv.value.real,
+                                lower=dv.lower,
+                                upper=dv.upper,
+                                scale=dv.scale,
                             )
                         else:
                             optProb.addVarGroup(
-                                dv.name, dv.nVal, "c", value=np.real(dv.value), lower=dv.value, upper=dv.value, scale=dv.scale
+                                dv.name,
+                                dv.nVal,
+                                "c",
+                                value=dv.value.real,
+                                lower=dv.value,
+                                upper=dv.value,
+                                scale=dv.scale,
                             )
 
         # Add variables from the children

--- a/pygeo/parameterization/DVGeo.py
+++ b/pygeo/parameterization/DVGeo.py
@@ -2976,23 +2976,11 @@ class DVGeometry(BaseDVGeometry):
                         dv = varLists[lst][key]
                         if key not in freezeVars:
                             optProb.addVarGroup(
-                                dv.name,
-                                dv.nVal,
-                                "c",
-                                value=dv.value.real,
-                                lower=dv.lower,
-                                upper=dv.upper,
-                                scale=dv.scale,
+                                dv.name, dv.nVal, "c", value=np.real(dv.value), lower=dv.lower, upper=dv.upper, scale=dv.scale
                             )
                         else:
                             optProb.addVarGroup(
-                                dv.name,
-                                dv.nVal,
-                                "c",
-                                value=dv.value.real,
-                                lower=dv.value,
-                                upper=dv.value,
-                                scale=dv.scale,
+                                dv.name, dv.nVal, "c", value=np.real(dv.value), lower=dv.value, upper=dv.value, scale=dv.scale
                             )
 
         # Add variables from the children
@@ -3716,6 +3704,7 @@ class DVGeometry(BaseDVGeometry):
             self.nDVG_count = 0
             self.nDVSL_count = self.nDVG_T
             self.nDVL_count = self.nDVG_T + self.nDVSL_T
+            self.nDVSW_count = self.nDVG_T + self.nDVSL_T + self.nDVL_T
 
         nDVG = self._getNDVGlobalSelf()
         nDVL = self._getNDVLocalSelf()
@@ -3734,7 +3723,7 @@ class DVGeometry(BaseDVGeometry):
             child.nDVG_count = self.nDVG_count + nDVG
             child.nDVL_count = self.nDVL_count + nDVL
             child.nDVSL_count = self.nDVSL_count + nDVSL
-            child.nDVSW_count = self.nDVSW_count + nDVSL
+            child.nDVSW_count = self.nDVSW_count + nDVSW
 
             # Increment the counters for the children
             nDVG += child._getNDVGlobalSelf()


### PR DESCRIPTION
## Purpose
The title says it all. 
It's a small fix for cases where you have spanwiseLocalDV and other variables.
Right now, `self.nDVSW_count` defaults to 0 causing it to overwrite other columns of the Jacobian. 

## Expected time until merged
1 week

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)



## Checklist

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
