### PR TITLE
Error if derivative mode other than "rev" is requested for `OM_DVGEOCOMP`

### DIFF
--- a/pygeo/mphys/mphys_dvgeo.py
+++ b/pygeo/mphys/mphys_dvgeo.py
@@ -947,3 +947,5 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
                                     # in multiple objective seeds with totalSensitivity. we can remove the [0]
                                     # once we move back to totalSensitivityTransProd
                                     d_inputs[k] += xdotg[k][0]
+        else:
+            raise RuntimeError(f"OM_DVGEOCOMP supports only \"rev\" derivative mode, but \"{mode}\" was selected")

--- a/pygeo/mphys/mphys_dvgeo.py
+++ b/pygeo/mphys/mphys_dvgeo.py
@@ -947,5 +947,5 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
                                     # in multiple objective seeds with totalSensitivity. we can remove the [0]
                                     # once we move back to totalSensitivityTransProd
                                     d_inputs[k] += xdotg[k][0]
-        else:
+        elif mode != "rev":
             raise RuntimeError(f"OM_DVGEOCOMP supports only \"rev\" derivative mode, but \"{mode}\" was selected")


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
The MPhys component for pygeo supports only reverse mode derivatives and otherwise gives zero derivatives. However, no warning or error is thrown. This PR adds a `RuntimeError` if the derivatives are requested with a mode other than `"rev"`.

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
A few days

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
