### PR TITLE
MPhys wrapper improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ doc/_build
 input_files
 .isort.cfg
 *.vscode
-tests/reg_tests/reports/
+tests/reg_tests/test_MPhysGeo*_out

--- a/pygeo/mphys/mphys_dvgeo.py
+++ b/pygeo/mphys/mphys_dvgeo.py
@@ -36,6 +36,8 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
         # since `nom_add_discipline_coords` can be called before `setup`
         self.omPtInOutDict = {}
 
+        self.update_jac = True
+
     def setup(self):
         # create a constraints object to go with this DVGeo(s)
         self.DVCon = DVConstraints()

--- a/pygeo/mphys/mphys_dvgeo.py
+++ b/pygeo/mphys/mphys_dvgeo.py
@@ -269,6 +269,12 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
         DVGeometry object
             DVGeometry object held by this geometry component
         """
+        # Calling this function before setup is not allowed because the DVGeo object(s) do not exist yet
+        if not hasattr(self, "DVGeos"):
+            raise RuntimeError(
+                "Cannot call `nom_getDVGeo` before OM_DVGEOCOMP's `setup` method has been called. If you are calling this function in the `setup` method of a group containing an OM_DVGEOCOMP, move the call to `configure` instead."
+            ) from None
+
         # if we have multiple DVGeos use the one specified by name
         if self.multDVGeo:
             DVGeo = self.DVGeos[DVGeoName]

--- a/pygeo/mphys/mphys_dvgeo.py
+++ b/pygeo/mphys/mphys_dvgeo.py
@@ -1,3 +1,4 @@
+# Standard Python modules
 import inspect
 
 # External modules

--- a/pygeo/mphys/mphys_dvgeo.py
+++ b/pygeo/mphys/mphys_dvgeo.py
@@ -225,22 +225,18 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
             self.add_input(inputName, distributed=True, val=points.flatten())
             self.add_output(outputName, distributed=True, val=points.flatten())
 
-    def nom_addPointSet(self, points, ptName, add_output=True, DVGeoName=None, **kwargs):
+    def nom_addPointSet(self, points, ptName, add_output=True, DVGeoName=None, distributed=True, **kwargs):
         # if we have multiple DVGeos use the one specified by name
         DVGeo = self.nom_getDVGeo(DVGeoName=DVGeoName)
 
         # add the points to the dvgeo object
-        dMaxGlobal = None
-        if isinstance(DVGeo, DVGeometryESP):
-            # DVGeoESP can return a value to check the pointset distribution
-            dMaxGlobal = DVGeo.addPointSet(points.reshape(len(points) // 3, 3), ptName, **kwargs)
-        else:
-            DVGeo.addPointSet(points.reshape(len(points) // 3, 3), ptName, **kwargs)
+        # DVGeoESP can return a value to check the pointset distribution
+        dMaxGlobal = DVGeo.addPointSet(points.reshape(-1, 3), ptName, **kwargs)
         self.omPtSetList.append(ptName)
 
         if add_output:
             # add an output to the om component
-            self.add_output(ptName, distributed=True, val=points.flatten())
+            self.add_output(ptName, distributed=distributed, val=points.flatten())
 
         return dMaxGlobal
 

--- a/pygeo/mphys/mphys_dvgeo.py
+++ b/pygeo/mphys/mphys_dvgeo.py
@@ -226,11 +226,31 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
             self.add_output(outputName, distributed=True, val=points.flatten())
 
     def nom_addPointSet(self, points, ptName, add_output=True, DVGeoName=None, distributed=True, **kwargs):
+        """Add a pointset to the DVGeo object and create an output for it in the OpenMDAO component.
+
+        Parameters
+        ----------
+        points : numpy array
+            3D points to add to the DVGeo object, shape (N,3) or (3N,)
+        ptName : str
+            Name for the pointset
+        add_output : bool, optional
+            Whether to add the deformed points as an output of the component, by default True
+        DVGeoName : str, optional
+            The name of the DVGeo to add the points to, necessary if there are multiple DVGeo objects. By default `None`.
+        distributed : bool, optional
+            Whether the output of the component should be a distributed variable, by default True
+
+        Returns
+        -------
+        None or float
+            If using DVGeometryESP or DVGeometryVSP, returns the maximum distance between pointset and the CAD model
+        """
         # if we have multiple DVGeos use the one specified by name
         DVGeo = self.nom_getDVGeo(DVGeoName=DVGeoName)
 
         # add the points to the dvgeo object
-        # DVGeoESP can return a value to check the pointset distribution
+        # DVGeoESP and DVGeoVSP can return a value to check the pointset distribution
         dMaxGlobal = DVGeo.addPointSet(points.reshape(-1, 3), ptName, **kwargs)
         self.omPtSetList.append(ptName)
 

--- a/pygeo/mphys/mphys_dvgeo.py
+++ b/pygeo/mphys/mphys_dvgeo.py
@@ -102,7 +102,7 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
             for _, DVGeo in self.DVGeos.items():
                 self.DVCon.setDVGeo(DVGeo, name=DVConName)
 
-        self.omPtSetList = {}
+        self.omPtSets = {}
 
     def compute(self, inputs, outputs):
         # check for inputs that have been added but the points have not been added to dvgeo
@@ -112,7 +112,7 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
                 # retrieve corresponding output name
                 var_out = self.omPtInOutDict[var]
                 # add pointset if it doesn't already exist
-                if var_out not in self.omPtSetList:
+                if var_out not in self.omPtSets:
                     self.nom_addPointSet(inputs[var], var_out, add_output=False)
 
         # handle DV update and pointset changes for all of our DVGeos
@@ -122,7 +122,7 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
 
             # ouputs are the coordinates of the pointsets we have
             for ptName in DVGeo.points:
-                if ptName in self.omPtSetList:
+                if ptName in self.omPtSets:
                     # update this pointset and write it as output
                     outputs[ptName] = DVGeo.update(ptName).flatten()
 
@@ -262,7 +262,7 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
             dMaxGlobal = DVGeo.addPointSet(points.reshape(-1, 3), ptName, distributed=distributed, **kwargs)
         else:
             dMaxGlobal = DVGeo.addPointSet(points.reshape(-1, 3), ptName, **kwargs)
-        self.omPtSetList[ptName] = {"distributed": distributed}
+        self.omPtSets[ptName] = {"distributed": distributed}
 
         if add_output:
             # add an output to the om component
@@ -1101,7 +1101,7 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
                     ptSetNames = DVGeo.ptSetNames
 
                 for ptSetName in ptSetNames:
-                    if ptSetName in self.omPtSetList:
+                    if ptSetName in self.omPtSets:
                         # Process the seeds
                         if doFwd:
                             # Collect the d_inputs associated with the current DVGeo
@@ -1133,7 +1133,7 @@ class OM_DVGEOCOMP(om.ExplicitComponent):
                                     # check if this dv is present
                                     if k in d_inputs:
                                         # do the allreduce if the pointset is distributed
-                                        if self.omPtSetList[ptSetName]["distributed"]:
+                                        if self.omPtSets[ptSetName]["distributed"]:
                                             xdotg[k] = self.comm.allreduce(xdot[k], op=MPI.SUM)
                                         else:
                                             xdotg[k] = xdot[k]

--- a/tests/reg_tests/test_MPhysGeo.py
+++ b/tests/reg_tests/test_MPhysGeo.py
@@ -266,6 +266,8 @@ test_params_constraints_box = [
 @unittest.skipUnless(omInstalled, "OpenMDAO is required to test the pyGeo MPhys wrapper")
 @parameterized_class(ffd_test_params)
 class TestDVGeoMPhysFFD(unittest.TestCase):
+    N_PROCS = 2
+
     def setUp(self):
         # give the OM Group access to the test case attributes
         dvInfo = self.dvInfo
@@ -286,7 +288,7 @@ class TestDVGeoMPhysFFD(unittest.TestCase):
                 points[0, :] = [0.25, 0, 0]
                 points[1, :] = [-0.25, 0, 0]
                 ptName = "testPoints"
-                self.geometry.nom_addPointSet(points.flatten(), ptName)
+                self.geometry.nom_addPointSet(points.flatten(), ptName, distributed=False)
 
                 # create a reference axis for the parent
                 axisPoints = [[-1.0, 0.0, 0.0], [1.5, 0.0, 0.0]]

--- a/tests/reg_tests/test_MPhysGeo.py
+++ b/tests/reg_tests/test_MPhysGeo.py
@@ -562,5 +562,20 @@ class TestDVGeoMPhysESP(unittest.TestCase):
         commonUtils.assert_check_totals(totals, atol=1e-5, rtol=1e-5)
 
 
+@unittest.skipUnless(omInstalled, "OpenMDAO is required to test the pyGeo MPhys wrapper")
+class TestGetDVGeoError(unittest.TestCase):
+    # Make sure we get an error if we try to call nom_getDVGeo before setup
+    def test_getDVGeo_error(self):
+        class BadGroup(Group):
+            def setup(self):
+                geometryComp = OM_DVGEOCOMP(file=outerFFD, type="ffd")
+                self.add_subsystem("geometry", geometryComp, promotes=["*"])
+                geometryComp.nom_getDVGeo()
+
+        prob = Problem(model=BadGroup())
+        with self.assertRaises(RuntimeError):
+            prob.setup()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/reg_tests/test_MPhysGeo.py
+++ b/tests/reg_tests/test_MPhysGeo.py
@@ -323,7 +323,7 @@ class TestDVGeoMPhysFFD(unittest.TestCase):
 
                 self.add_constraint(f"geometry.{ptName}")
 
-        self.prob = Problem(model=FFDGroup())
+        self.prob = Problem(model=FFDGroup(), reports=False)
 
     def test_run_model(self):
         self.prob.setup()
@@ -404,7 +404,7 @@ class TestDVConMPhysBox(unittest.TestCase):
                 self.add_design_var("local")
                 self.add_objective(paramKwargs["name"])
 
-        p = Problem(model=BoxGeo())
+        p = Problem(model=BoxGeo(), reports=False)
         return p
 
     def test_undeformed_vals(self):
@@ -529,7 +529,7 @@ class TestDVGeoMPhysESP(unittest.TestCase):
 
                 self.add_constraint(f"geometry.{ptName}")
 
-        self.prob = Problem(model=ESPGroup())
+        self.prob = Problem(model=ESPGroup(), reports=False)
 
     def test_run_model(self):
         self.prob.setup()
@@ -572,7 +572,7 @@ class TestGetDVGeoError(unittest.TestCase):
                 self.add_subsystem("geometry", geometryComp, promotes=["*"])
                 geometryComp.nom_getDVGeo()
 
-        prob = Problem(model=BadGroup())
+        prob = Problem(model=BadGroup(), reports=False)
         with self.assertRaises(RuntimeError):
             prob.setup()
 


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
### 1: Improvements to `nom_addPointSet`

1. Adds argument allowing users to control whether output points are distributed, this required some changes to `compute_jacvec_product` to avoid adding up duplicate derivative values for non-distributed pointsets
2. Removes unnecessary if statement
3. Changes call to `reshape` so that it works whether supplied points are flattened or (N,3) array

### 2: Addresses #273 

### 3: Add helpful error message if `nom_getDVGeo` is called before `setup`
The DVGeo instances associated with an instance of `OM_DVGEOCOMP` are only created when `setup` is called. Because OpenMDAO calls `setup` starting from top level groups and works down, calling `nom_getDVGeo` (or another method that calls it such as `nom_addPointSet`) in the `setup` method of an OpenMDAO group that contains an `OM_DVGEOCOMP` will cause an error. However, the error message that currently gets raised when you do this doesn't make this obvious:

```
Traceback (most recent call last):
  File "/home/ali/repos/AerostructuralOptBenchmark/runscripts/aeroStructRun-MultipointParallel.py", line 855, in <module>
    flightPointProb.setup(force_alloc_complex=isComplex, mode="rev")
  File "/home/ali/.pyenv/versions/MACH312/lib/python3.12/site-packages/openmdao/core/problem.py", line 1164, in setup
    model._setup(model_comm, self._metadata)
  File "/home/ali/.pyenv/versions/MACH312/lib/python3.12/site-packages/openmdao/core/group.py", line 830, in _setup
    self._setup_procs(self.pathname, comm, prob_meta)
  File "/home/ali/.pyenv/versions/MACH312/lib/python3.12/site-packages/openmdao/core/group.py", line 645, in _setup_procs
    self.setup()
  File "/home/ali/repos/AerostructuralOptBenchmark/runscripts/aeroStructRun-MultipointParallel.py", line 566, in setup
    geometryComp.nom_addPointSet(wimpressCalc.getCoords(packed=True), ptName=wimpressCoordName)
  File "/home/ali/repos/pygeo/pygeo/mphys/mphys_dvgeo.py", line 230, in nom_addPointSet
    DVGeo = self.nom_getDVGeo(DVGeoName=DVGeoName)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ali/repos/pygeo/pygeo/mphys/mphys_dvgeo.py", line 273, in nom_getDVGeo
    if self.multDVGeo:
       ^^^^^^^^^^^^^^
AttributeError: 'OM_DVGEOCOMP' object has no attribute 'multDVGeo'
```

This PR adds a helpful error that is raised in these cases that recommends users move their function call to the `configure` method, where `nom_getDVGeo` will work:

```
Traceback (most recent call last):
  File "/home/ali/repos/AerostructuralOptBenchmark/runscripts/aeroStructRun-MultipointParallel.py", line 856, in <module>
    flightPointProb.setup(force_alloc_complex=isComplex, mode="rev")
  File "/home/ali/.pyenv/versions/MACH312/lib/python3.12/site-packages/openmdao/core/problem.py", line 1164, in setup
    model._setup(model_comm, self._metadata)
  File "/home/ali/.pyenv/versions/MACH312/lib/python3.12/site-packages/openmdao/core/group.py", line 830, in _setup
    self._setup_procs(self.pathname, comm, prob_meta)
  File "/home/ali/.pyenv/versions/MACH312/lib/python3.12/site-packages/openmdao/core/group.py", line 645, in _setup_procs
    self.setup()
  File "/home/ali/repos/AerostructuralOptBenchmark/runscripts/aeroStructRun-MultipointParallel.py", line 568, in setup
    geometryComp.nom_addPointSet(wimpressCalc.getCoords(packed=True), ptName=wimpressCoordName)
  File "/home/ali/repos/pygeo/pygeo/mphys/mphys_dvgeo.py", line 230, in nom_addPointSet
    DVGeo = self.nom_getDVGeo(DVGeoName=DVGeoName)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ali/repos/pygeo/pygeo/mphys/mphys_dvgeo.py", line 274, in nom_getDVGeo
    raise RuntimeError(
RuntimeError: Cannot call `nom_getDVGeo` before OM_DVGEOCOMP's `setup` method has been called. If you are calling this function in the `setup` method of a group containing an OM_DVGEOCOMP, move the call to `configure` instead.
```

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
Soon

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `ruff check` and `ruff format` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
