### PR TITLE
Fix race condition in test_examples tearDown

### DIFF
--- a/tests/reg_tests/test_examples.py
+++ b/tests/reg_tests/test_examples.py
@@ -62,6 +62,11 @@ class TestExamples(unittest.TestCase):
         self.common_test("deform_geometry", "runScript.py", args=["--input_type", input_type])
 
     def tearDown(self):
-        for f in self.output_file_list:
-            os.remove(f)
-        os.chdir(self.cwd)
+        try:
+            for f in self.output_file_list:
+                try:
+                    os.remove(f)
+                except FileNotFoundError:
+                    pass
+        finally:
+            os.chdir(self.cwd)


### PR DESCRIPTION
## Purpose

The three parameterized `test_deform` variants in `tests/reg_tests/test_examples.py` all `chdir` into `examples/deform_geometry/` and write the same `wingNew.plt` file. When each test finishes it tries to delete the `wingNew.plt` file and then `chdir` back to the original directory:

```python
    def tearDown(self):
        for f in self.output_file_list:
            os.remove(f)
        os.chdir(self.cwd)
```

When testflo runs these tests in parallel, this causes two failures:

1. `test_deform_*` fails in `tearDown` with `FileNotFoundError: 'wingNew.plt'` — one worker's `tearDown` removes the file before another worker's `tearDown` gets to it.
2. This `FileNotFoundError` means the worker never moves back out of the examples directory, causes the following tests that the worker tries to run to fail.

Symptoms:
- Both failures only appear when running the full parallel suite (`testflo -v .`)
- Running the failing tests in isolation always passes
- The `test_DVConstraints` failures show `(00:00:0.00, 0 MB)` — instant fail at the test-framework import stage, never executed

## Fix

Wrap the cleanup in `try/finally` and swallow `FileNotFoundError` so:
- The CWD is always restored, even if file removal raises
- The race on `wingNew.plt` removal is harmless

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing

Before the fix, `testflo -v .` on this branch yielded ~14 failures (1 in `test_examples`, the rest cascading `ModuleNotFoundError`s in `test_DVConstraints`). After the fix, `testflo -v .` reports `Passed: 266, Failed: 0, Skipped: 88` across 32 processes.

## Checklist

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted (ruff via pre-commit)
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation